### PR TITLE
Updated pagination part in the Quick Example doc

### DIFF
--- a/docs/api_controller/index.md
+++ b/docs/api_controller/index.md
@@ -2,9 +2,10 @@
 
 APIController is a borrowed term from the C# ASP.NET environment which is an MVC framework. Although Django is not an MVC framework, we can still mimic the concept generally just like any other programming concept.
 
-Django-Ninja-Extra APIController is modelled after C# ASP.NET ApiController, giving all OOP sense in creating your controller models and adapting recent software design patterns in your Django project. 
+Django-Ninja-Extra APIController is modelled after C# ASP.NET ApiController, giving all OOP sense in creating your controller models and adapting recent software design patterns in your Django project.
 
 ### Why APIController in Django.
+
 I come from a background where we model anything in class based object, and I have worked with many API tools out there in python: DRF, FastAPI, Flask-Restful. It is either function based or class tailored to function based.
 Don't get me wrong, there are still great libraries. In fact, some features of Django-Ninja-Extra came from DRF. So I am a big fan. I needed more.
 
@@ -14,18 +15,20 @@ So I designed APIController to extend Django-Ninja to class-based and have somet
 
 So if you enjoy class-based controls for building API, welcome aboard.
 
-
 ## ControllerBase
+
 ```python
 class ControllerBase(ABC):
     ...
 ```
+
 APIController decorates any class with `ControllerBase` if its not inheriting from it.
 
 !!!info
-    Inheriting from ControllerBase class gives you more IDE intellisense support.
+Inheriting from ControllerBase class gives you more IDE intellisense support.
 
 ## Quick Example
+
 Let's create an APIController to manage Django user model
 
 ```python
@@ -66,9 +69,9 @@ class UsersController(ControllerBase):
         user = self.get_object_or_exception(self.user_model, id=user_id)
         user.delete()
         return self.create_response('', status_code=status.HTTP_204_NO_CONTENT)
-    
-    @http_get('', response=List[UserSchema])
-    @pagination.paginate
+
+    @http_get('', response=pagination.PaginatedResponseSchema[UserSchema])
+    @pagination.paginate(pagination.PageNumberPaginationExtra, page_size=50)
     def list_user(self):
         return self.user_model.objects.all()
 


### PR DESCRIPTION
Hi! 

I was trying the sample code in the [Quick Example documentation](https://eadwincode.github.io/django-ninja-extra/api_controller/), and the sample code throws the following error:
```
raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for NinjaResponseSchema
response -> results
  field required (type=value_error.missing)
```

Looking further into the documentation, it seems that the `pagination.paginate` decorator no longer works well with `List[UserSchema]`, so I modified it to `pagination.PaginatedResponseSchema[UserSchema]` and the decorator to `pagination.paginate(pagination.PageNumberPaginationExtra, page_size=50)` and it worked.

I have updated the docs accordingly, I hope you find this helpful.