### PR TITLE
fix: controller_instance.check_permissions can not use django-orm

### DIFF
--- a/ninja_extra/controllers/route/route_functions.py
+++ b/ninja_extra/controllers/route/route_functions.py
@@ -170,9 +170,11 @@ class AsyncRouteFunction(RouteFunction):
             *args: Any,
             **kwargs: Any,
         ) -> Any:
+            from asgiref.sync import sync_to_async
+
             context = context or cast(RouteContext, service_resolver(RouteContext))
             with self._prep_controller_route_execution(context, **kwargs) as ctx:
-                ctx.controller_instance.check_permissions()
+                await sync_to_async(ctx.controller_instance.check_permissions)()
                 result = await self.route.view_func(
                     ctx.controller_instance, *args, **ctx.view_func_kwargs
                 )


### PR DESCRIPTION
When you add django-orm operations in has_permission, the system will fail with this exception:
`django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.`

For example:
```
    def has_permission(
        self, request: HttpRequest, controller: "ControllerBase"
    ) -> bool:
        user = request.user
        has_perm = True
        if hasattr(controller, "model"):
            model = controller.model
            app = model._meta.app_label
            has_perm = user.has_perm(f"{app}.view_{model.__name__}")
            if request.method in ("PATCH", "POST"):
                has_perm = user.has_perm(f"{app}.change_{model.__name__}")
        return bool(user and user.is_authenticated and user.is_active and has_perm)
```

This quick patch will provide a fix. 