### PR TITLE
Fix `@api_controller` type signature

### DIFF
--- a/ninja_extra/controllers/base.py
+++ b/ninja_extra/controllers/base.py
@@ -469,7 +469,7 @@ class APIController:
 @overload
 def api_controller(
     prefix_or_class: Type,
-) -> Union[Type[ControllerBase], Callable[..., Any], Any]:  # pragma: no cover
+) -> Union[Type[ControllerBase]]:  # pragma: no cover
     ...
 
 
@@ -480,7 +480,7 @@ def api_controller(
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
-) -> Union[Type[ControllerBase], Callable[..., Any], Any]:  # pragma: no cover
+) -> Union[Callable[..., ControllerBase]]:  # pragma: no cover
     ...
 
 
@@ -490,7 +490,7 @@ def api_controller(
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
-) -> Union[Type[ControllerBase], Callable[..., Any], Any]:
+) -> Union[Type[ControllerBase], Callable[..., ControllerBase]]:
     if isinstance(prefix_or_class, type):
         return APIController(
             prefix="",

--- a/ninja_extra/controllers/base.py
+++ b/ninja_extra/controllers/base.py
@@ -316,7 +316,7 @@ class APIController:
             tag = [value]
         self._tags = tag
 
-    def __call__(self, cls: Type) -> Union[Type, Type["ControllerBase"]]:
+    def __call__(self, cls: Type) -> Type[ControllerBase]:
         from ninja_extra.throttling import throttle
 
         self.auto_import = getattr(cls, "auto_import", self.auto_import)
@@ -469,7 +469,7 @@ class APIController:
 @overload
 def api_controller(
     prefix_or_class: Type,
-) -> Union[Type[ControllerBase]]:  # pragma: no cover
+) -> Type[ControllerBase]:  # pragma: no cover
     ...
 
 
@@ -480,7 +480,7 @@ def api_controller(
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
-) -> Union[Callable[..., ControllerBase]]:  # pragma: no cover
+) -> Callable[[Type], Type[ControllerBase]]:  # pragma: no cover
     ...
 
 
@@ -490,7 +490,7 @@ def api_controller(
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
-) -> Union[Type[ControllerBase], Callable[..., ControllerBase]]:
+) -> Union[Type[ControllerBase], Callable[[Type], Type[ControllerBase]]]:
     if isinstance(prefix_or_class, type):
         return APIController(
             prefix="",
@@ -500,7 +500,7 @@ def api_controller(
             auto_import=auto_import,
         )(prefix_or_class)
 
-    def _decorator(cls: Type) -> Union[Type[ControllerBase], Any]:
+    def _decorator(cls: Type) -> Type[ControllerBase]:
         return APIController(
             prefix=str(prefix_or_class),
             auth=auth,


### PR DESCRIPTION
The typing overloads for the `@api_controller` decorator currently both specify a `Union[Type[ControllerBase], Callable[..., Any], Any]` return type. This is a more general type than what is actually returned, and this results in spurious typing errors. For example,

```python
@api_controller("/path-prefix/")
class MyController(ControllerBase):
    ...
```

results in the following error in mypy:

```
 error: Too many arguments for "ControllerBase"  [call-arg]
```

The `api_controller()` function always returns a `Callable[..., ControllerBase]` when `prefix_or_class` is a string because it needs to return the inner `_decorator()` method in that case so that the controller class can be decorated by the return value. If a `ControllerBase` subclass were to be returned instead, then there would be a runtime error because this class couldn't be used as a decorator, and this is what the mypy error is telling us.

This PR narrows the typing on `@api_controller` and its overloads to better reflect the implementation and resolve the above issue.