### PR TITLE
feat(pagination): support adding response headers by passing response

### DIFF
--- a/ninja_extra/pagination.py
+++ b/ninja_extra/pagination.py
@@ -225,6 +225,7 @@ class PaginatorOperation:
             ), "Request object is None"
             params = dict(kw)
             params["request"] = controller.context.request
+            params["response"] = controller.context.response
             return self.paginator.paginate_queryset(items, **params)
 
         return as_view


### PR DESCRIPTION
Hi!

First contribution here, if anything needs changing let me know.

I'm making use of django-ninja-extra in a project of mine, and I have the need to paginate using [link header pagination](https://medium.com/@jules.cheron/header-pagination-the-easy-way-with-drf-5724d6864cb).

This MR allows for setting the headers by passing the response to `paginate_queryset()`.

