### PR TITLE
Update typing for api_controller decorator

### DIFF
--- a/ninja_extra/controllers/base.py
+++ b/ninja_extra/controllers/base.py
@@ -14,6 +14,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
     overload,
@@ -517,13 +518,16 @@ def api_controller(
     ...
 
 
+InputClassType = TypeVar("InputClassType", bound=ControllerBase)
+
+
 def api_controller(
     prefix_or_class: Union[str, Type] = "",
     auth: Any = NOT_SET,
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
-) -> Union[Type[ControllerBase], Callable[[Type], Type[ControllerBase]]]:
+) -> Union[Type[ControllerBase], Callable[[InputClassType], Type[InputClassType]]]:
     if isinstance(prefix_or_class, type):
         return APIController(
             prefix="",
@@ -533,7 +537,7 @@ def api_controller(
             auto_import=auto_import,
         )(prefix_or_class)
 
-    def _decorator(cls: Type) -> Type[ControllerBase]:
+    def _decorator(cls: InputClassType) -> Type[InputClassType]:
         return APIController(
             prefix=str(prefix_or_class),
             auth=auth,


### PR DESCRIPTION
This fixes IDEs complaining about static methods not existing when called on the class.

For example, in Pycharm the `.some_static({"test":"me")` gets marked with a warning:
```python
@api_controller("/")
class SomeController(ControllerBase):
    @route.post("some_endpoint")
    def some_endpoint(self, params: dict):
        return self.some_static(params)  # This is fine

    @staticmethod
    def some_static(params):
        return some_static

SomeController.some_static({"test":"me")  # This is not: "Unresolved attribute reference 'some_static' for class 'ControllerBase'"
```
![image](https://github.com/eadwinCode/django-ninja-extra/assets/1719461/ef38b841-e961-4a75-a602-dcfd8115ae7f)


With the typing fix:
![image](https://github.com/eadwinCode/django-ninja-extra/assets/1719461/a951c664-c3df-493f-9600-4ad5f3e15bd7)
