### PR TITLE
feat: Ninja  V1.2.0 Support

### DIFF
--- a/ninja_extra/conf/settings.py
+++ b/ninja_extra/conf/settings.py
@@ -41,7 +41,12 @@ class NinjaExtraSettings(BaseModel):
     THROTTLE_RATES: Dict[str, Optional[str]] = Field(
         {"user": "1000/day", "anon": "100/day"}
     )
-    THROTTLE_CLASSES: List[Any] = []
+    THROTTLE_CLASSES: List[Any] = Field(
+        [
+            "ninja_extra.throttling.AnonRateThrottle",
+            "ninja_extra.throttling.UserRateThrottle",
+        ]
+    )
     NUM_PROXIES: Optional[int] = None
     INJECTOR_MODULES: List[Any] = []
     ORDERING_CLASS: Any = Field(

--- a/ninja_extra/constants.py
+++ b/ninja_extra/constants.py
@@ -15,6 +15,7 @@ OPTIONS = "OPTIONS"
 TRACE = "TRACE"
 ROUTE_METHODS = [POST, PUT, PATCH, DELETE, GET, HEAD, OPTIONS, TRACE]
 THROTTLED_FUNCTION = "__throttled_endpoint__"
+THROTTLED_OBJECTS = "__throttled_objects__"
 ROUTE_FUNCTION = "__route_function__"
 
 ROUTE_CONTEXT_VAR: contextvars.ContextVar[t.Optional["RouteContext"]] = (

--- a/ninja_extra/controllers/base.py
+++ b/ninja_extra/controllers/base.py
@@ -531,6 +531,7 @@ def api_controller(
 def api_controller(
     prefix_or_class: str = "",
     auth: Any = NOT_SET,
+    throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
@@ -543,6 +544,7 @@ def api_controller(
 def api_controller(
     prefix_or_class: Union[str, Union[ControllerClassType, Type]] = "",
     auth: Any = NOT_SET,
+    throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
     tags: Union[Optional[List[str]], str] = None,
     permissions: Optional["PermissionType"] = None,
     auto_import: bool = True,
@@ -554,6 +556,7 @@ def api_controller(
             tags=tags,
             permissions=permissions,
             auto_import=auto_import,
+            throttle=throttle,
         )(prefix_or_class)
 
     def _decorator(cls: ControllerClassType) -> ControllerClassType:
@@ -563,6 +566,7 @@ def api_controller(
             tags=tags,
             permissions=permissions,
             auto_import=auto_import,
+            throttle=throttle,
         )(cls)
 
     return _decorator

--- a/ninja_extra/controllers/route/__init__.py
+++ b/ninja_extra/controllers/route/__init__.py
@@ -1,7 +1,8 @@
 import typing as t
 
-from ninja.constants import NOT_SET
+from ninja.constants import NOT_SET, NOT_SET_TYPE
 from ninja.signature import is_async
+from ninja.throttling import BaseThrottle
 from ninja.types import TCallable
 
 from ninja_extra.constants import (
@@ -52,6 +53,7 @@ class Route(object):
         path: str,
         methods: t.List[str],
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -97,6 +99,7 @@ class Route(object):
             path=path,
             methods=methods,
             auth=auth,
+            throttle=throttle,
             response=_response,
             operation_id=operation_id,
             summary=summary,
@@ -124,6 +127,7 @@ class Route(object):
         path: str,
         methods: t.List[str],
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -164,6 +168,7 @@ class Route(object):
             include_in_schema=include_in_schema,
             permissions=permissions,
             openapi_extra=openapi_extra,
+            throttle=throttle,
         )
         route_function_class = RouteFunction
         if route_obj.is_async:
@@ -178,6 +183,7 @@ class Route(object):
         path: str = "",
         *,
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -242,6 +248,7 @@ class Route(object):
                 include_in_schema=include_in_schema,
                 permissions=permissions,
                 openapi_extra=openapi_extra,
+                throttle=throttle,
             )
 
         return decorator
@@ -252,6 +259,7 @@ class Route(object):
         path: str = "",
         *,
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -316,6 +324,7 @@ class Route(object):
                 include_in_schema=include_in_schema,
                 permissions=permissions,
                 openapi_extra=openapi_extra,
+                throttle=throttle,
             )
 
         return decorator
@@ -326,6 +335,7 @@ class Route(object):
         path: str = "",
         *,
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -390,6 +400,7 @@ class Route(object):
                 include_in_schema=include_in_schema,
                 permissions=permissions,
                 openapi_extra=openapi_extra,
+                throttle=throttle,
             )
 
         return decorator
@@ -400,6 +411,7 @@ class Route(object):
         path: str = "",
         *,
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -465,6 +477,7 @@ class Route(object):
                 include_in_schema=include_in_schema,
                 permissions=permissions,
                 openapi_extra=openapi_extra,
+                throttle=throttle,
             )
 
         return decorator
@@ -475,6 +488,7 @@ class Route(object):
         path: str = "",
         *,
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -540,6 +554,7 @@ class Route(object):
                 include_in_schema=include_in_schema,
                 permissions=permissions,
                 openapi_extra=openapi_extra,
+                throttle=throttle,
             )
 
         return decorator
@@ -551,6 +566,7 @@ class Route(object):
         *,
         methods: t.List[str],
         auth: t.Any = NOT_SET,
+        throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: t.Union[t.Any, t.List[t.Any]] = NOT_SET,
         operation_id: t.Optional[str] = None,
         summary: t.Optional[str] = None,
@@ -617,6 +633,7 @@ class Route(object):
                 include_in_schema=include_in_schema,
                 permissions=permissions,
                 openapi_extra=openapi_extra,
+                throttle=throttle,
             )
 
         return decorator

--- a/ninja_extra/router.py
+++ b/ninja_extra/router.py
@@ -1,7 +1,8 @@
-from typing import Any, Callable, Dict, List, Optional, get_type_hints
+from typing import Any, Callable, Dict, List, Optional, Union, get_type_hints
 
-from ninja.constants import NOT_SET
+from ninja.constants import NOT_SET, NOT_SET_TYPE
 from ninja.router import Router as NinjaRouter
+from ninja.throttling import BaseThrottle
 
 from ninja_extra.operation import PathView
 
@@ -10,9 +11,13 @@ __all__ = ["Router"]
 
 class Router(NinjaRouter):
     def __init__(
-        self, *, auth: Any = NOT_SET, tags: Optional[List[str]] = None
+        self,
+        *,
+        auth: Any = NOT_SET,
+        tags: Optional[List[str]] = None,
+        throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
     ) -> None:
-        super().__init__(auth=auth, tags=tags)
+        super().__init__(auth=auth, tags=tags, throttle=throttle)
         self.path_operations: Dict[str, PathView] = {}  # type: ignore
 
     def add_api_operation(
@@ -22,6 +27,7 @@ class Router(NinjaRouter):
         view_func: Callable,
         *,
         auth: Any = NOT_SET,
+        throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
         response: Any = NOT_SET,
         operation_id: Optional[str] = None,
         summary: Optional[str] = None,
@@ -47,6 +53,7 @@ class Router(NinjaRouter):
 
         path_view.add_operation(
             path=path,
+            throttle=throttle,
             methods=methods,
             view_func=view_func,
             auth=auth,

--- a/ninja_extra/schemas/response.py
+++ b/ninja_extra/schemas/response.py
@@ -2,6 +2,8 @@ import dataclasses
 from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 from ninja import Schema
+from ninja.constants import NOT_SET, NOT_SET_TYPE
+from ninja.throttling import BaseThrottle
 from pydantic import BeforeValidator, TypeAdapter, field_validator
 from pydantic.networks import HttpUrl
 from typing_extensions import Annotated
@@ -57,6 +59,7 @@ class RouteParameter:
     methods: List[str]
     openapi_extra: Optional[Dict[str, Any]]
     auth: Optional[Union[Type, Any]] = None
+    throttle: Union[BaseThrottle, List[BaseThrottle], NOT_SET_TYPE] = NOT_SET
     response: Optional[Union[Type, Any]] = None
     operation_id: Optional[str] = None
     summary: Optional[str] = None

--- a/ninja_extra/throttling/__init__.py
+++ b/ninja_extra/throttling/__init__.py
@@ -1,7 +1,8 @@
+from ninja.throttling import BaseThrottle
+
 from .decorator import throttle
 from .model import (
     AnonRateThrottle,
-    BaseThrottle,
     DynamicRateThrottle,
     SimpleRateThrottle,
     UserRateThrottle,

--- a/ninja_extra/throttling/decorator.py
+++ b/ninja_extra/throttling/decorator.py
@@ -1,70 +1,85 @@
 import inspect
-from functools import wraps
-from typing import Any, Callable, List, Optional, Type, Union, cast
+from typing import Any, Callable, List, Type, Union
 
-from django.http import HttpRequest, HttpResponse
-from ninja.signature import is_async
+from ninja.throttling import BaseThrottle
 
-from ninja_extra import exceptions
 from ninja_extra.conf import settings
-from ninja_extra.constants import THROTTLED_FUNCTION
-from ninja_extra.controllers import ControllerBase, RouteContext
-from ninja_extra.dependency_resolver import service_resolver
-
-from .model import BaseThrottle
+from ninja_extra.constants import THROTTLED_FUNCTION, THROTTLED_OBJECTS
 
 
-def throttle(*func_or_throttle_classes: Any, **init_kwargs: Any) -> Callable[..., Any]:
+def throttle(
+    *func_or_throttle_klass_or_object: Any, **init_kwargs: Any
+) -> Callable[..., Any]:
     isfunction = (
-        inspect.isfunction(func_or_throttle_classes[0])
-        if len(func_or_throttle_classes) == 1
+        inspect.isfunction(func_or_throttle_klass_or_object[0])
+        if len(func_or_throttle_klass_or_object) == 1
         else False
     )
 
     if isfunction:
-        func = func_or_throttle_classes[0]
+        func = func_or_throttle_klass_or_object[0]
         throttle_classes: List[Type[BaseThrottle]] = settings.THROTTLE_CLASSES
         return _inject_throttling(func, *throttle_classes, **init_kwargs)
 
     def wrapper(view_func: Callable[..., Any]) -> Any:
-        return _inject_throttling(view_func, *func_or_throttle_classes, **init_kwargs)
+        return _inject_throttling(
+            view_func, *func_or_throttle_klass_or_object, **init_kwargs
+        )
 
     return wrapper
 
 
-def _run_throttles(
-    *throttle_classes: Type[BaseThrottle],
-    request_or_controller: Union[HttpRequest, ControllerBase],
-    response: Optional[HttpResponse] = None,
+# def _run_throttles(
+#     *throttle_classes: Type[BaseThrottle],
+#     request_or_controller: Union[HttpRequest, ControllerBase],
+#     response: Optional[HttpResponse] = None,
+#     **init_kwargs: Any,
+# ) -> None:
+#     """
+#     Run all throttles for a request.
+#     Raises an appropriate exception if the request is throttled.
+#     """
+#
+#     request = cast(
+#         HttpRequest,
+#         (
+#             request_or_controller.context.request  # type:ignore
+#             if isinstance(request_or_controller, ControllerBase)
+#             else request_or_controller
+#         ),
+#     )
+#
+#     throttle_durations = []
+#
+#     for throttle_class in throttle_classes:
+#         throttling: BaseThrottle = throttle_class(**init_kwargs)
+#         if not throttling.allow_request(request):
+#             # Filter out `None` values which may happen in case of config / rate
+#             duration = throttling.wait()
+#             if duration is not None:
+#                 throttle_durations.append(duration)
+#
+#     if throttle_durations:
+#         duration = max(throttle_durations, default=None)
+#         raise exceptions.Throttled(duration)
+
+
+def _lazy_throttling_objects(
+    *throttle_klass_or_object: Union[Type[BaseThrottle], BaseThrottle],
     **init_kwargs: Any,
-) -> None:
-    """
-    Run all throttles for a request.
-    Raises an appropriate exception if the request is throttled.
-    """
+) -> Callable:
+    def _() -> List[BaseThrottle]:
+        res = []
+        for item in throttle_klass_or_object:
+            if isinstance(item, type):
+                res.append(item(**init_kwargs))
+                continue
 
-    request = cast(
-        HttpRequest,
-        (
-            request_or_controller.context.request  # type:ignore
-            if isinstance(request_or_controller, ControllerBase)
-            else request_or_controller
-        ),
-    )
+            res.append(item)
 
-    throttle_durations = []
+        return res
 
-    for throttle_class in throttle_classes:
-        throttling: BaseThrottle = throttle_class(**init_kwargs)
-        if not throttling.allow_request(request):
-            # Filter out `None` values which may happen in case of config / rate
-            duration = throttling.wait()
-            if duration is not None:
-                throttle_durations.append(duration)
-
-    if throttle_durations:
-        duration = max(throttle_durations, default=None)
-        raise exceptions.Throttled(duration)
+    return _
 
 
 def _inject_throttling(
@@ -72,53 +87,59 @@ def _inject_throttling(
     *throttle_classes: Type[BaseThrottle],
     **init_kwargs: Any,
 ) -> Callable[..., Any]:
+    throttling_objects_lazy: Callable = _lazy_throttling_objects(
+        *throttle_classes, **init_kwargs
+    )
     setattr(func, THROTTLED_FUNCTION, True)
-    if is_async(func):
-        return _async_inject_throttling_handler(func, *throttle_classes, **init_kwargs)
-    return _sync_inject_throttling_handler(func, *throttle_classes, **init_kwargs)
+    setattr(func, THROTTLED_OBJECTS, throttling_objects_lazy)
+
+    return func
+    # if is_async(func):
+    #     return _async_inject_throttling_handler(func, *throttle_classes, **init_kwargs)
+    # return _sync_inject_throttling_handler(func, *throttle_classes, **init_kwargs)
 
 
-def _sync_inject_throttling_handler(
-    func: Callable[..., Any],
-    *throttle_classes: Type[BaseThrottle],
-    **init_kwargs: Any,
-) -> Callable[..., Any]:
-    @wraps(func)
-    def as_view(
-        request_or_controller: Union[HttpRequest, ControllerBase], *args: Any, **kw: Any
-    ) -> Any:
-        ctx = cast(Optional[RouteContext], service_resolver(RouteContext))
-        _run_throttles(
-            *throttle_classes,
-            request_or_controller=request_or_controller,
-            response=ctx.response if ctx else None,
-            **init_kwargs,
-        )
-
-        res = func(request_or_controller, *args, **kw)
-        return res
-
-    return as_view
-
-
-def _async_inject_throttling_handler(
-    func: Callable[..., Any],
-    *throttle_classes: Type[BaseThrottle],
-    **init_kwargs: Any,
-) -> Callable[..., Any]:
-    @wraps(func)
-    async def as_view(
-        request_or_controller: Union[HttpRequest, ControllerBase], *args: Any, **kw: Any
-    ) -> Any:
-        ctx = cast(Optional[RouteContext], service_resolver(RouteContext))
-        _run_throttles(
-            *throttle_classes,
-            request_or_controller=request_or_controller,
-            response=ctx.response if ctx else None,
-            **init_kwargs,
-        )
-
-        res = await func(request_or_controller, *args, **kw)
-        return res
-
-    return as_view
+# def _sync_inject_throttling_handler(
+#     func: Callable[..., Any],
+#     *throttle_classes: Type[BaseThrottle],
+#     **init_kwargs: Any,
+# ) -> Callable[..., Any]:
+#     @wraps(func)
+#     def as_view(
+#         request_or_controller: Union[HttpRequest, ControllerBase], *args: Any, **kw: Any
+#     ) -> Any:
+#         ctx = cast(Optional[RouteContext], service_resolver(RouteContext))
+#         _run_throttles(
+#             *throttle_classes,
+#             request_or_controller=request_or_controller,
+#             response=ctx.response if ctx else None,
+#             **init_kwargs,
+#         )
+#
+#         res = func(request_or_controller, *args, **kw)
+#         return res
+#
+#     return as_view
+#
+#
+# def _async_inject_throttling_handler(
+#     func: Callable[..., Any],
+#     *throttle_classes: Type[BaseThrottle],
+#     **init_kwargs: Any,
+# ) -> Callable[..., Any]:
+#     @wraps(func)
+#     async def as_view(
+#         request_or_controller: Union[HttpRequest, ControllerBase], *args: Any, **kw: Any
+#     ) -> Any:
+#         ctx = cast(Optional[RouteContext], service_resolver(RouteContext))
+#         _run_throttles(
+#             *throttle_classes,
+#             request_or_controller=request_or_controller,
+#             response=ctx.response if ctx else None,
+#             **init_kwargs,
+#         )
+#
+#         res = await func(request_or_controller, *args, **kw)
+#         return res
+#
+#     return as_view

--- a/ninja_extra/throttling/model.py
+++ b/ninja_extra/throttling/model.py
@@ -1,67 +1,15 @@
-"""
-Provides various throttling policies.
-From DjangoRestFramework - https://github.com/encode/django-rest-framework/blob/master/rest_framework/throttling.py
-"""
-
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional
 
 from django.core.cache import cache as default_cache
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
+from ninja.throttling import SimpleRateThrottle as BaseSimpleRateThrottle
 
 from ninja_extra.conf import settings
 
 
-class BaseThrottle:
-    """
-    Rate throttling of requests.
-    """
-
-    THROTTLE_RATES: Optional[Dict] = None
-
-    def __init__(self) -> None:
-        self.key: Optional[str] = None
-
-        self.history: List[float] = []
-        self.now: float = 0.0
-        self.num_requests: Optional[int] = None
-        self.duration: Optional[int] = None
-
-    def allow_request(self, request: HttpRequest) -> bool:
-        """
-        Return `True` if the request should be allowed, `False` otherwise.
-        """
-        raise NotImplementedError(".allow_request() must be overridden")
-
-    def get_ident(self, request: HttpRequest) -> Optional[str]:
-        """
-        Identify the machine making the request by parsing HTTP_X_FORWARDED_FOR
-        if present and number of proxies is > 0. If not use all of
-        HTTP_X_FORWARDED_FOR if it is available, if not use REMOTE_ADDR.
-        """
-        xff = request.META.get("HTTP_X_FORWARDED_FOR")
-        remote_addr = request.META.get("REMOTE_ADDR")
-        num_proxies = settings.NUM_PROXIES
-
-        if num_proxies is not None:
-            if num_proxies == 0 or xff is None:
-                return remote_addr
-            addrs = xff.split(",")
-            client_addr = addrs[-min(num_proxies, len(addrs))]
-            return cast(str, client_addr.strip())
-
-        return "".join(xff.split()) if xff else remote_addr
-
-    def wait(self) -> Optional[float]:  # pragma: no cover
-        """
-        Optionally, return a recommended number of seconds to wait before
-        the next request.
-        """
-        return None
-
-
-class SimpleRateThrottle(BaseThrottle):
+class SimpleRateThrottle(BaseSimpleRateThrottle):
     """
     A simple cache implementation, that only requires `.get_cache_key()`
     to be overridden.
@@ -79,11 +27,16 @@ class SimpleRateThrottle(BaseThrottle):
     cache_format: str = "throttle_%(scope)s_%(ident)s"
     scope: Optional[str] = None
 
-    def __init__(self) -> None:
-        super(SimpleRateThrottle, self).__init__()
-        if not getattr(self, "rate", None):
-            self.rate = self.get_rate()
-        self.num_requests, self.duration = self.parse_rate(self.rate)
+    def __init__(self, rate: Optional[str] = None) -> None:
+        if not rate and hasattr(self, "rate"):
+            rate = getattr(self, "rate", None)
+        super(SimpleRateThrottle, self).__init__(rate)
+
+    def get_throttling_rates(self) -> Dict[str, Optional[str]]:
+        rates = self.THROTTLE_RATES.copy()
+        rates.update(settings.THROTTLE_RATES)
+
+        return rates
 
     def get_cache_key(self, request: HttpRequest) -> Optional[str]:
         """
@@ -105,26 +58,12 @@ class SimpleRateThrottle(BaseThrottle):
             )
             raise ImproperlyConfigured(msg)
 
-        _THROTTLE_RATES = self.THROTTLE_RATES or settings.THROTTLE_RATES
+        _THROTTLE_RATES = self.get_throttling_rates()
         try:
             return _THROTTLE_RATES[self.scope]
         except KeyError as e:
             msg = "No default throttle rate set for '%s' scope" % self.scope
             raise ImproperlyConfigured(msg) from e
-
-    def parse_rate(
-        self, rate: Optional[str] = None
-    ) -> Tuple[Optional[int], Optional[int]]:
-        """
-        Given the request rate string, return a two tuple of:
-        <allowed number of requests>, <period of time in seconds>
-        """
-        if rate is None:
-            return None, None
-        num, period = rate.split("/")
-        num_requests = int(num)
-        duration = {"s": 1, "m": 60, "h": 3600, "d": 86400}[period[0]]
-        return num_requests, duration
 
     def allow_request(self, request: HttpRequest) -> bool:
         """
@@ -136,54 +75,27 @@ class SimpleRateThrottle(BaseThrottle):
         if self.rate is None:
             return True
 
-        self.key = self.get_cache_key(request)
-        if self.key is None:
-            return True
+        return super().allow_request(request)
 
-        self.history = self.cache.get(self.key, [])
-        self.now = self.timer()
-
-        # Drop any requests from the history which have now passed the
-        # throttle duration
-        while (
-            self.history and self.history[-1] <= self.now - self.duration  # type:ignore
-        ):
-            self.history.pop()
-        if len(self.history) >= self.num_requests:  # type:ignore
-            return self.throttle_failure()
-        return self.throttle_success()
-
-    def throttle_success(self) -> bool:
+    def get_ident(self, request: HttpRequest) -> Optional[str]:
         """
-        Inserts the current request's timestamp along with the key
-        into the cache.
+        Identify the machine making the request by parsing HTTP_X_FORWARDED_FOR
+        if present and number of proxies is > 0. If not use all of
+        HTTP_X_FORWARDED_FOR if it is available, if not use REMOTE_ADDR.
         """
-        self.history.insert(0, self.now)
-        self.cache.set(self.key, self.history, self.duration)
-        return True
 
-    def throttle_failure(self) -> bool:
-        """
-        Called when a request to the API has failed due to throttling.
-        """
-        return False
+        xff = request.META.get("HTTP_X_FORWARDED_FOR")
+        remote_addr = request.META.get("REMOTE_ADDR")
+        num_proxies = settings.NUM_PROXIES
 
-    def wait(self) -> Optional[float]:
-        """
-        Returns the recommended next request time in seconds.
-        """
-        assert self.duration is not None and self.num_requests is not None
+        if num_proxies is not None:
+            if num_proxies == 0 or xff is None:
+                return remote_addr
+            addrs: List[str] = xff.split(",")
+            client_addr = addrs[-min(num_proxies, len(addrs))]
+            return client_addr.strip()
 
-        if self.history:
-            remaining_duration = self.duration - (self.now - self.history[-1])
-        else:
-            remaining_duration = self.duration
-
-        available_requests = self.num_requests - len(self.history) + 1
-        if available_requests <= 0:
-            return None
-
-        return remaining_duration / float(available_requests)
+        return "".join(xff.split()) if xff else remote_addr
 
 
 class AnonRateThrottle(SimpleRateThrottle):
@@ -231,15 +143,15 @@ class DynamicRateThrottle(SimpleRateThrottle):
     the API. Set Throttle scope dynamically for an api endpoint
     """
 
-    def __init__(self, scope: Optional[str] = None) -> None:
+    def __init__(self, rate: Optional[str] = None, scope: Optional[str] = None) -> None:
         self.scope = scope
-        super().__init__()
+        super().__init__(rate)
 
     def get_cache_key(self, request: HttpRequest) -> Optional[str]:
         """
         If `scope` is not set during initialization, don't apply this throttle.
 
-        Otherwise generate the unique cache key by concatenating the user id
+        Otherwise, generate the unique cache key by concatenating the user id
         with the `.throttle_scope` property of the view.
         """
         if request.user and request.user.is_authenticated:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ warn_unused_ignores = true
 disallow_untyped_defs = true
 check_untyped_defs = true
 no_implicit_reexport = true
+disable_error_code = ['var-annotated', 'misc']
 
 [[tool.mypy.overrides]]
 module = "ninja_extra.compatible.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 
 requires = [
     "Django >= 2.2",
-    "django-ninja==1.1.0",
+    "django-ninja>=1.2.0",
     "injector >= 0.19.0",
     "asgiref",
     "contextlib2"

--- a/tests/test_throthling/test_throttle_decorator_on_controllers.py
+++ b/tests/test_throthling/test_throttle_decorator_on_controllers.py
@@ -24,12 +24,9 @@ class ThrottledController:
         return "foo"
 
     @http_get("/dynamic_throttling_scope")
-    @throttle(DynamicRateThrottle, scope="dynamic_scope")
+    @throttle(DynamicRateThrottle("3/min"))
     def dynamic_throttling_scope(self, request):
         return "foo"
-
-
-client = TestClient(ThrottledController)
 
 
 class TestThrottledController:
@@ -40,6 +37,12 @@ class TestThrottledController:
     def test_requests_are_throttled_using_default_user_scope(self, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(settings, "THROTTLE_RATES", {"user": "3/sec", "anon": "2/sec"})
+
+            cloned_controller = api_controller(
+                type("ThrottledController", (ThrottledController,), {})
+            )
+            client = TestClient(cloned_controller)
+
             for _dummy in range(4):
                 response = client.get("/throttle_user_default", user=self.user)
             assert response.status_code == 429
@@ -48,6 +51,7 @@ class TestThrottledController:
         """
         Ensure request rate is limited
         """
+        client = TestClient(ThrottledController)
 
         for _dummy in range(4):
             response = client.get("/throttle_user_3_sec", user=self.user)
@@ -55,17 +59,16 @@ class TestThrottledController:
 
     def test_request_throttling_for_dynamic_throttling(self, monkeypatch):
         # for authenticated user
-        with monkeypatch.context() as m:
-            m.setattr(settings, "THROTTLE_RATES", {"dynamic_scope": "3/min"})
-            for _dummy in range(4):
-                response = client.get("/dynamic_throttling_scope", user=self.user)
-            assert response.status_code == 429
+        client = TestClient(ThrottledController)
+
+        for _dummy in range(4):
+            response = client.get("/dynamic_throttling_scope", user=self.user)
+        assert response.status_code == 429
         # for unauthenticated user
-        with monkeypatch.context() as m:
-            m.setattr(settings, "THROTTLE_RATES", {"dynamic_scope": "3/min"})
-            for _dummy in range(4):
-                client.get("/dynamic_throttling_scope")
-            assert response.status_code == 429
+
+        for _dummy in range(4):
+            client.get("/dynamic_throttling_scope")
+        assert response.status_code == 429
 
 
 @pytest.mark.skipif(django.VERSION < (3, 1), reason="requires django 3.1 or higher")
@@ -94,8 +97,13 @@ async def test_async_controller_throttling(monkeypatch):
 
     with monkeypatch.context() as m:
         m.setattr(settings, "THROTTLE_RATES", {"user": "3/sec", "anon": "2/sec"})
+        cloned_controller = api_controller(
+            type("ThrottledControllerAsync", (ThrottledControllerAsync,), {})
+        )
+        client = TestAsyncClient(cloned_controller)
+
         for _dummy in range(4):
-            response = await client_async.get("/throttle_user_default_async", user=user)
+            response = await client.get("/throttle_user_default_async", user=user)
         assert response.status_code == 429
 
     user = create_user()

--- a/tests/test_throthling/test_throttling_xxf.py
+++ b/tests/test_throthling/test_throttling_xxf.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from django.core.cache import cache
 from ninja.testing import TestClient
 
-from ninja_extra import NinjaExtraAPI, throttle
+from ninja_extra import NinjaExtraAPI
 from ninja_extra.conf import settings
 from ninja_extra.throttling import DynamicRateThrottle
 
@@ -19,8 +19,7 @@ class Throttle(DynamicRateThrottle):
 api = NinjaExtraAPI(urls_namespace="decorator_xxf")
 
 
-@api.get("/throttling_xxf")
-@throttle(Throttle, scope="test_limit")
+@api.get("/throttling_xxf", throttle=Throttle(scope="test_limit"))
 def throttling_xxf(request):
     return "foo"
 


### PR DESCRIPTION
## What's changed
- Adapted throttling model to Ninja Throttling pattern.
- Ninja version bumped up

**N.B**

The current implementation of Ninja Throttle followed a different usage but the classes/functions are still the same. Because of this, there is now a clash between NINJA_EXTRA  and NINJA  throttling settings resulting in having similar throttling classes between both packages that are distinguished by their settings. 
This is temporary and, also a backward compatibility support for projects already using the NINJA_EXTRA throttling pattern in Controller classes.

Projects using the `@throttle` decorator, should switch to the **route definition** `throttle` parameter as described in the [`Ninja throttling doc`](https://django-ninja.dev/guides/throttling/). The `@throttle` will be deprecated soon in later versions of this package. Currently, the `@throttle` decorator moves the throttling class or object to  **route definition** `throttle` and does nothing else.