### PR TITLE
bugfix: OperandHolder object can't transmit the permission message.

### DIFF
--- a/ninja_extra/permissions/common.py
+++ b/ninja_extra/permissions/common.py
@@ -38,6 +38,7 @@ class IsAdminUser(BasePermission):
     """
     Allows access only to admin users.
     """
+    message: str = "You must be an admin user to access this resource."
 
     def has_permission(
         self, request: HttpRequest, controller: "ControllerBase"


### PR DESCRIPTION
BasePermission subclass message can't transmit up to `ninja_extra/controllers/base.py:L181` `check_permissions`

From #193 , I try the double permission with `|` and `&`, but the ninja always return the message is None.
I tried to debug why the message can't be transmitted from my Custom BasePermission subclass and found that the permission object is from `self._get_permissions()`, `ninja_extra.permissions.base.OR object` does not transmit the message attribute from input BasePermissions.
So I write these code and test cases to fix this problem.

```log
---------- coverage: platform linux, python 3.12.3-final-0 -----------
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
ninja_extra/__init__.py                               10      0   100%
ninja_extra/apps.py                                   19      0   100%
ninja_extra/compatible.py                              5      0   100%
ninja_extra/conf/__init__.py                           2      0   100%
ninja_extra/conf/settings.py                          56      0   100%
ninja_extra/constants.py                              16      0   100%
ninja_extra/controllers/__init__.py                    7      0   100%
ninja_extra/controllers/base.py                      208      0   100%
ninja_extra/controllers/model/__init__.py              6      0   100%
ninja_extra/controllers/model/builder.py              67      0   100%
ninja_extra/controllers/model/endpoints.py           190      0   100%
ninja_extra/controllers/model/interfaces.py            7      0   100%
ninja_extra/controllers/model/path_resolver.py        82      0   100%
ninja_extra/controllers/model/schemas.py              97      0   100%
ninja_extra/controllers/model/service.py              45      0   100%
ninja_extra/controllers/registry.py                   20      0   100%
ninja_extra/controllers/response.py                   14      0   100%
ninja_extra/controllers/route/__init__.py             85      0   100%
ninja_extra/controllers/route/context.py              19      0   100%
ninja_extra/controllers/route/route_functions.py      91      0   100%
ninja_extra/dependency_resolver.py                    29      0   100%
ninja_extra/details.py                                 9      0   100%
ninja_extra/exceptions.py                            138      0   100%
ninja_extra/generic.py                                22      0   100%
ninja_extra/helper.py                                 11      0   100%
ninja_extra/lazy.py                                   17      0   100%
ninja_extra/logger.py                                  2      0   100%
ninja_extra/main.py                                   64      0   100%
ninja_extra/modules.py                                16      0   100%
ninja_extra/operation.py                             171      3    98%   122-123, 254
ninja_extra/ordering.py                              134      0   100%
ninja_extra/pagination/__init__.py                     6      0   100%
ninja_extra/pagination/decorator.py                   28      0   100%
ninja_extra/pagination/models/__init__.py              2      0   100%
ninja_extra/pagination/models/page_by_number.py       58      0   100%
ninja_extra/pagination/operations.py                  52      0   100%
ninja_extra/permissions/__init__.py                    3      0   100%
ninja_extra/permissions/base.py                       68      0   100%
ninja_extra/permissions/common.py                     20      0   100%
ninja_extra/router.py                                 21      0   100%
ninja_extra/schemas/__init__.py                        3      0   100%
ninja_extra/schemas/response.py                       48      0   100%
ninja_extra/searching.py                             134      0   100%
ninja_extra/security/__init__.py                       6      0   100%
ninja_extra/security/api_key.py                       15      0   100%
ninja_extra/security/http.py                          30      0   100%
ninja_extra/security/session.py                       11      0   100%
ninja_extra/shortcuts.py                              51      0   100%
ninja_extra/signals.py                                 0      0   100%
ninja_extra/status.py                                 70      0   100%
ninja_extra/testing/__init__.py                        2      0   100%
ninja_extra/testing/client.py                         33      0   100%
ninja_extra/throttling/__init__.py                     4      0   100%
ninja_extra/throttling/decorator.py                   29      3    90%   20-22
ninja_extra/throttling/model.py                       68      0   100%
ninja_extra/types.py                                   3      0   100%
ninja_extra/urls.py                                   14      0   100%
--------------------------------------------------------------------------------
TOTAL                                               2438      6    99%

================================================= 290 passed, 36 warnings in 5.34s =================================================
```