### PR TITLE
fix(Injector): When django_injector is install and replace injector instance, add ninja_extra module

### DIFF
--- a/ninja_extra/apps.py
+++ b/ninja_extra/apps.py
@@ -27,6 +27,7 @@ class NinjaExtraConfig(AppConfig):
         if app:  # pragma: no cover
             app.ready()
             self.injector = app.injector
+            self.injector.binder.install(self.ninja_extra_module)
         self.register_injector_modules()
 
     def register_injector_modules(self) -> None:  # pragma: no cover


### PR DESCRIPTION
Hello, 

I am currently working with django_injector and I noticed that the ninja_extra module was no longer loaded when it was detected.  I have added the module's configuration to that of django_injector.

Without adding the ninja_extra module, I no longer had access to the request in my controller. 

Let me know if you need more information :)

Or the second solution is to add : 
```
INJECTOR_MODULES = [
    "ninja_extra.modules.NinjaExtraModule",
    ...
]
```

Quentin
