### PR TITLE
fix: Controller Operation Order

### DIFF
--- a/ninja_extra/__init__.py
+++ b/ninja_extra/__init__.py
@@ -1,6 +1,6 @@
 """Django Ninja Extra - Class Based Utility and more for Django Ninja(Fast Django REST framework)"""
 
-__version__ = "0.21.7"
+__version__ = "0.21.8"
 
 import django
 

--- a/ninja_extra/controllers/base.py
+++ b/ninja_extra/controllers/base.py
@@ -1,6 +1,7 @@
 import inspect
 import re
 import uuid
+from abc import ABC
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -62,9 +63,24 @@ class MissingAPIControllerDecoratorException(Exception):
 
 
 def get_route_functions(cls: Type) -> Iterable[RouteFunction]:
-    for _, method in inspect.getmembers(cls, predicate=inspect.isfunction):
-        if hasattr(method, ROUTE_FUNCTION):
-            yield getattr(method, ROUTE_FUNCTION)
+    """
+    Get all route functions from a controller class.
+    This function will recursively search for route functions in the base classes of the controller class
+    in order that they are defined.
+
+    Args:
+        cls (Type): The controller class.
+
+    Returns:
+        Iterable[RouteFunction]: An iterable of route functions.
+    """
+
+    bases = inspect.getmro(cls)
+    for base_cls in reversed(bases):
+        if base_cls not in [ControllerBase, ABC, object]:
+            for method in base_cls.__dict__.values():
+                if hasattr(method, ROUTE_FUNCTION):
+                    yield getattr(method, ROUTE_FUNCTION)
 
 
 def get_all_controller_route_function(


### PR DESCRIPTION
## What's changed
- Maintained controller operation definition order during route computation. That way, routes that are defined first take precedence over others in a Controller class