### PR TITLE
fix: RouteContext Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Django Ninja Extra is a powerful extension for [Django Ninja](https://django-nin
 - 📝 **Type Safety**: Comprehensive type hints for better development experience
 - 🎯 **Django Integration**: Seamless integration with Django's ecosystem
 - 📚 **OpenAPI Support**: Automatic API documentation with Swagger/ReDoc
+- 🔒 **API Throttling**: Rate limiting for your API
 
 ### Extra Features
 - 🏗️ **Class-Based Controllers**: 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,6 @@
 
 # Django Ninja Extra
 
-## Overview
-
 Django Ninja Extra is a powerful extension for [Django Ninja](https://django-ninja.rest-framework.com) that enhances your Django REST API development experience. It introduces class-based views and advanced features while maintaining the high performance and simplicity of Django Ninja. Whether you're building a small API or a large-scale application, Django Ninja Extra provides the tools you need for clean, maintainable, and efficient API development.
 
 ## Features
@@ -20,6 +18,7 @@ Django Ninja Extra is a powerful extension for [Django Ninja](https://django-nin
 - 📝 **Type Safety**: Comprehensive type hints for better development experience
 - 🎯 **Django Integration**: Seamless integration with Django's ecosystem
 - 📚 **OpenAPI Support**: Automatic API documentation with Swagger/ReDoc
+- 🔒 **API Throttling**: Rate limiting for your API
 
 ### Extra Features
 - 🏗️ **Class-Based Controllers**: 
@@ -43,6 +42,7 @@ Django Ninja Extra is a powerful extension for [Django Ninja](https://django-nin
   - Reusable components
 
 ## Requirements
+
 - Python >= 3.6
 - Django >= 2.1
 - Pydantic >= 1.6
@@ -161,7 +161,7 @@ class UserController:
 
 Access your API's interactive documentation at `/api/docs`:
 
-![Swagger UI](docs/images/ui_swagger_preview_readme.gif)
+![Swagger UI](/images/ui_swagger_preview_readme.gif)
 
 ## Learning Resources
 

--- a/ninja_extra/__init__.py
+++ b/ninja_extra/__init__.py
@@ -1,6 +1,6 @@
 """Django Ninja Extra - Class Based Utility and more for Django Ninja(Fast Django REST framework)"""
 
-__version__ = "0.22.0"
+__version__ = "0.22.2"
 
 import django
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -165,7 +165,15 @@ class TestAPIController:
         group_instance = Group.objects.create(name="_groupowner")
 
         controller_object = SomeController()
-        context = RouteContext(request=Mock(), permission_classes=[AllowAny])
+        context = RouteContext(
+            request=Mock(),
+            permission_classes=[AllowAny],
+            response=None,
+            args=[],
+            kwargs={},
+            api=None,
+            view_signature=None,
+        )
         controller_object.context = context
         with patch.object(
             AllowAny, "has_object_permission", return_value=True


### PR DESCRIPTION
## What's changed
- Ability to manually trigger route parameter computation. #227 
```python
class IsUserAllowedToUpdate(BasePermission):
    def has_permission(self, request: HttpRequest, controller) -> bool:
          if not controller.context.has_computed_route_parameters:
              controller.context.compute_route_parameters()
              
        data = controller.context.kwargs.get('data')
        mydata= data.mydata
```
This is important for cases where permission depends on route parameter data that has not been computed at the point of running the route permissions.