### PR TITLE
Min page size

### DIFF
--- a/ninja_extra/pagination/models/page_by_number.py
+++ b/ninja_extra/pagination/models/page_by_number.py
@@ -26,7 +26,7 @@ logger = logging.getLogger()
 class PageNumberPaginationExtra(PaginationBase):
     class Input(Schema):
         page: int = Field(1, gt=0)
-        page_size: int = Field(100, lt=200)
+        page_size: int = Field(100, gt=0, lt=200)
 
     page_query_param = "page"
     page_size_query_param = "page_size"
@@ -48,7 +48,7 @@ class PageNumberPaginationExtra(PaginationBase):
     def create_input(self) -> Type[Input]:
         class DynamicInput(PageNumberPaginationExtra.Input):
             page: int = Field(1, gt=0)
-            page_size: int = Field(self.page_size, lt=self.max_page_size)
+            page_size: int = Field(self.page_size, gt=0, lt=self.max_page_size)
 
         return DynamicInput
 

--- a/ninja_extra/pagination/models/page_by_number.py
+++ b/ninja_extra/pagination/models/page_by_number.py
@@ -26,7 +26,7 @@ logger = logging.getLogger()
 class PageNumberPaginationExtra(PaginationBase):
     class Input(Schema):
         page: int = Field(1, gt=0)
-        page_size: int = Field(100, gt=0, lt=200)
+        page_size: int = Field(100, gt=0, lt=201)
 
     page_query_param = "page"
     page_size_query_param = "page_size"
@@ -48,7 +48,7 @@ class PageNumberPaginationExtra(PaginationBase):
     def create_input(self) -> Type[Input]:
         class DynamicInput(PageNumberPaginationExtra.Input):
             page: int = Field(1, gt=0)
-            page_size: int = Field(self.page_size, gt=0, lt=self.max_page_size)
+            page_size: int = Field(self.page_size, gt=0, lt=self.max_page_size + 1)
 
         return DynamicInput
 

--- a/tests/test_model_controller/test_model_controller_schema.py
+++ b/tests/test_model_controller/test_model_controller_schema.py
@@ -105,6 +105,7 @@ def test_event_model_open_api_schema_case_4():
                 "title": "Page Size",
                 "default": 100,
                 "exclusiveMaximum": 200,
+                "exclusiveMinimum": 0,
                 "type": "integer",
             },
             "required": False,
@@ -149,6 +150,7 @@ def test_event_model_open_api_auto_gen_schema():
             "schema": {
                 "default": 100,
                 "exclusiveMaximum": 200,
+                "exclusiveMinimum": 0,
                 "title": "Page Size",
                 "type": "integer",
             },

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -217,6 +217,21 @@ class TestPagination:
             "results": [90, 91, 92, 93, 94, 95, 96, 97, 98, 99],
         }
 
+    @pytest.mark.parametrize("page_size", [-1, 0])
+    def test_case4_invalid_page_size(self, page_size: int):
+        response = client.get(f"/items_4?page_size={page_size}")
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": [
+                {
+                    "ctx": {"gt": 0},
+                    "loc": ["query", "page_size"],
+                    "msg": "Input should be greater than 0",
+                    "type": "greater_than",
+                }
+            ]
+        }
+
     def test_case4(self):
         response = client.get("/items_4?page=2").json()
         assert response.get("results") == ITEMS[10:20]
@@ -225,7 +240,6 @@ class TestPagination:
         assert response.get("previous") == "http://testlocation/"
 
         schema = api.get_openapi_schema()["paths"]["/api/items_4"]["get"]
-        # print(schema)
         assert schema["parameters"] == [
             {
                 "in": "query",
@@ -245,6 +259,7 @@ class TestPagination:
                     "title": "Page Size",
                     "default": 10,
                     "exclusiveMaximum": 200,
+                    "exclusiveMinimum": 0,
                     "type": "integer",
                 },
                 "required": False,


### PR DESCRIPTION
The schema of `PageNumberPaginationExtra` doesn't enforce a minimum value for the page size. It's possible to query a paginated route with `page_size=-1` or with `page_size=0` (which will also cause a 500 because of a `DivisionByZeroError`).

It may be more sound to enforce a minimum value, in order to return a 422 instead of a 404 or a 500 when the users asks for a page size that makes no sense.