### PR TITLE
feat: Async Permission and Permission DI Support

### DIFF
--- a/docs/api_controller/api_controller_async_permission.md
+++ b/docs/api_controller/api_controller_async_permission.md
@@ -1,0 +1,341 @@
+# Async Permissions in Django Ninja Extra
+
+This guide explains how to use the asynchronous permissions system in Django Ninja Extra for efficient permission handling with async views and models.
+
+## Introduction
+
+Django Ninja Extra provides an asynchronous permissions system that builds upon the existing permissions framework, adding support for async/await syntax. This is particularly useful when:
+
+- Working with async views and controllers
+- Performing permission checks that involve database queries
+- Building efficient APIs that don't block the event loop
+
+The permission system in Django Ninja Extra has been redesigned to seamlessly integrate both synchronous and asynchronous permissions, making it easy to:
+
+- Create async-first permission classes
+- Mix sync and async permissions with logical operators
+- Use dependency injection with permissions
+- Easily migrate from sync to async permissions
+
+## Creating Async Permissions
+
+### Basic Async Permission
+
+To create a custom async permission, inherit from `AsyncBasePermission` and implement the `has_permission_async` method:
+
+```python
+from ninja_extra.permissions import AsyncBasePermission
+
+class IsUserPremiumAsync(AsyncBasePermission):
+    async def has_permission_async(self, request, controller):
+        # You can perform async database operations here
+        user = request.user
+        
+        # Async check (example using Django's async ORM methods)
+        subscription = await user.subscription.aget()
+        return subscription and subscription.is_premium
+        
+    # The sync version is automatically handled for you
+    # through async_to_sync conversion
+```
+
+### Using Built-in Permissions
+
+Django Ninja Extra's permission system automatically handles both sync and async operations for built-in permissions:
+
+```python
+from ninja_extra import api_controller, http_get
+from ninja_extra.permissions import IsAuthenticated, IsAdminUser
+
+@api_controller(permissions=[IsAuthenticated])
+class UserController:
+    @http_get("/profile", permissions=[IsAdminUser])
+    async def get_admin_profile(self, request):
+        # Only accessible to admin users
+        # IsAdminUser works with async views automatically
+        return {"message": "Admin profile"}
+```
+
+## Combining Permissions with Logical Operators
+
+The permission system supports combining permissions using logical operators (`&`, `|`, `~`):
+
+```python
+from ninja_extra import api_controller, http_get
+from ninja_extra.permissions import IsAuthenticated, IsAdminUser, AsyncBasePermission
+
+# Custom async permission
+class HasPremiumSubscriptionAsync(AsyncBasePermission):
+    async def has_permission_async(self, request, controller):
+        # Async check
+        user_profile = await request.user.profile.aget()
+        return user_profile.has_premium_subscription
+
+@api_controller("/content")
+class ContentController:
+    # User must be authenticated AND have premium subscription
+    @http_get("/premium", permissions=[IsAuthenticated() & HasPremiumSubscriptionAsync()])
+    async def premium_content(self, request):
+        return {"content": "Premium content"}
+    
+    # User must be authenticated OR an admin
+    @http_get("/special", permissions=[IsAuthenticated() | IsAdminUser()])
+    async def special_content(self, request):
+        return {"content": "Special content"}
+    
+    # User must be authenticated but NOT an admin
+    @http_get("/regular", permissions=[IsAuthenticated() & ~IsAdminUser()])
+    async def regular_content(self, request):
+        return {"content": "Regular user content"}
+```
+
+### How Permission Operators Work
+
+When permissions are combined with logical operators, they create instances of `AND`, `OR`, or `NOT` classes that automatically handle both sync and async permissions:
+
+- **AND**: Both permissions must return `True` (short-circuits on first `False`)
+- **OR**: At least one permission must return `True` (short-circuits on first `True`)
+- **NOT**: Inverts the result of the permission
+
+The operators intelligently dispatch to either `has_permission`/`has_object_permission` or `has_permission_async`/`has_object_permission_async` depending on the context and permission types.
+
+## Mixing Sync and Async Permissions
+
+You can seamlessly mix regular permissions with async permissions:
+
+```python
+from ninja_extra import api_controller, http_get
+from ninja_extra.permissions import IsAuthenticated, IsAdminUser, AsyncBasePermission
+
+# Custom async permission
+class IsProjectMemberAsync(AsyncBasePermission):
+    async def has_permission_async(self, request, controller):
+        project_id = controller.kwargs.get('project_id')
+        if not project_id:
+            return False
+        
+        # Async database query
+        return await is_member_of_project(request.user.id, project_id)
+
+@api_controller("/projects")
+class ProjectController:
+    # Mixing sync and async permissions
+    @http_get("/{project_id}/details", permissions=[IsAuthenticated() & IsProjectMemberAsync()])
+    async def project_details(self, request, project_id: int):
+        # The framework automatically handles the conversion between sync and async
+        project = await get_project_by_id(project_id)
+        return project
+```
+
+The permission system automatically handles conversions between sync and async:
+
+- When an async view calls a sync permission, it's wrapped with `sync_to_async`
+- When a sync view calls an async permission, it's wrapped with `async_to_sync`
+- Logical operators (`AND`, `OR`, `NOT`) intelligently handle mixed permission types
+
+## Object-Level Permissions
+
+For object-level permissions, implement the `has_object_permission_async` method:
+
+```python
+class IsOwnerAsync(AsyncBasePermission):
+    async def has_object_permission_async(self, request, controller, obj):
+        # Async check on the object
+        return obj.owner_id == request.user.id
+
+@api_controller("/posts")
+class PostController:
+    @http_get("/{post_id}")
+    async def get_post(self, request, post_id: int):
+        # The async_check_object_permissions method will be called automatically
+        # when using aget_object_or_exception or aget_object_or_none
+        post = await self.aget_object_or_exception(Post, id=post_id)
+        return {"title": post.title, "content": post.content}
+```
+
+## Using Dependency Injection with Permissions
+
+Django Ninja Extra's permission system now integrates with dependency injection:
+
+```python
+from injector import inject
+from ninja_extra import api_controller, http_get, service_resolver
+from ninja_extra.permissions import AsyncBasePermission
+
+class FeatureService:
+    def has_feature_access(self, user, feature):
+        # Check if user has access to a specific feature
+        return getattr(user, f'has_{feature}', False)
+
+
+class FeaturePermission(AsyncBasePermission):
+    __features__ = {}
+
+    feature: str = "basic"
+
+    @inject
+    def __init__(self, feature_service: FeatureService):
+        self.feature_service = feature_service
+        self.message = f"Must have access to {self.feature} feature"
+        
+    # Async version of permission check
+    async def has_permission_async(self, request, controller):
+        return self.feature_service.has_feature_access(request.user, self.feature)
+    
+    @classmethod
+    def create_as(cls, feature: str) -> Type[FeaturePermission]:
+        # Create a new permission class with the same attributes
+        if feature in cls.__features__:
+            return cls.__features__[feature]
+        permission_type =  type(f"{cls.__name__}_{feature}", (cls,), {"feature": feature})
+        cls.__features__[feature] = permission_type
+        return permission_type
+
+
+@api_controller('features')
+class FeatureController(ControllerBase):
+    @http_get('basic/', permissions=[FeaturePermission.create_as("basic")])
+    async def basic_feature(self):
+        return {"feature": "basic"}
+        
+    @http_get('premium/', permissions=[FeaturePermission.create_as("premium")])
+    async def premium_feature(self):
+        return {"feature": "premium"}
+        
+    # You can even combine injected permissions with operators
+    @http_get('both/', permissions=[FeaturePermission.create_as("basic") & FeaturePermission.create_as("premium")])
+    async def both_features(self):
+        return {"feature": "both"}
+```
+
+The permission system automatically resolves the dependencies for injected permissions.
+
+## How the Permission Resolution Works
+
+The permission system uses a sophisticated resolution mechanism:
+
+1. **Class vs Instance**: Permissions can be specified as either classes (`IsAuthenticated`) or instances (`IsAuthenticated()`).
+2. **Dependency Injection**: Classes decorated with `@inject` are resolved using the dependency injector.
+3. **Operator Handling**: When permissions are combined with operators, the resolution happens lazily, only when the permission is actually checked.
+
+This resolution process is handled by the `_get_permission_object` method in the operation classes (`AND`, `OR`, `NOT`).
+
+## Performance Considerations
+
+- Use `AsyncBasePermission` for async-first permission classes
+- For optimal performance with database queries, use async methods like `aget()`, `afilter()`, etc.
+- The permission system automatically handles conversion between sync and async contexts using `asgiref.sync`
+- Logical operators implement short-circuiting for efficiency
+
+## Complete Example
+
+```python
+from django.contrib.auth.models import User
+from asgiref.sync import sync_to_async
+from ninja_extra import api_controller, http_get, http_post, ControllerBase
+from ninja_extra.permissions import AsyncBasePermission, IsAuthenticated, AllowAny
+
+# Custom async permission
+class IsStaffOrOwnerAsync(AsyncBasePermission):
+    async def has_permission_async(self, request, controller):
+        return request.user.is_authenticated
+    
+    async def has_object_permission_async(self, request, controller, obj):
+        # Either the user is staff or owns the object
+        return request.user.is_staff or obj.owner_id == request.user.id
+
+# Controller using mixed permissions
+@api_controller("/users", permissions=[IsAuthenticated])
+class UserController(ControllerBase):
+    @http_get("/", permissions=[AllowAny])
+    async def list_users(self, request):
+        # Public endpoint
+        users = await sync_to_async(list)(User.objects.values('id', 'username')[:10])
+        return users
+    
+    @http_get("/{user_id}")
+    async def get_user(self, request, user_id: int):
+        # Protected by IsAuthenticated from the controller
+        user = await self.aget_object_or_exception(User, id=user_id)
+        return {"id": user.id, "username": user.username}
+    
+    @http_post("/update/{user_id}", permissions=[IsStaffOrOwnerAsync()])
+    async def update_user(self, request, user_id: int, data: dict):
+        # Protected by custom async permission
+        user = await self.aget_object_or_exception(User, id=user_id)
+        # Update user data
+        return {"status": "success"}
+```
+
+## Migrating from Sync Permissions
+
+If you already have sync permission classes that you want to make async, follow these steps:
+
+1. Change the base class from `BasePermission` to `AsyncBasePermission`
+2. Implement the async methods (`has_permission_async` and `has_object_permission_async`)
+3. Convert any blocking operations to their async equivalents
+4. Update your controller to use these permissions
+
+The framework will automatically handle the interoperability between sync and async permissions.
+
+## Testing Async Permissions
+
+Testing async permissions is straightforward using pytest-asyncio:
+
+```python
+import pytest
+from unittest.mock import Mock
+from django.contrib.auth.models import AnonymousUser
+from ninja_extra.permissions import AsyncBasePermission, IsAdminUser
+
+# Custom async permission for testing
+class CustomAsyncPermission(AsyncBasePermission):
+    async def has_permission_async(self, request, controller):
+        return request.user.is_authenticated
+
+@pytest.mark.asyncio
+async def test_async_permission():
+    # Create a mock request
+    authenticated_request = Mock(user=Mock(is_authenticated=True))
+    anonymous_request = Mock(user=AnonymousUser())
+    
+    # Test the permission
+    permission = CustomAsyncPermission()
+    assert await permission.has_permission_async(authenticated_request, None) is True
+    assert await permission.has_permission_async(anonymous_request, None) is False
+    
+    # Test with operators
+    combined = CustomAsyncPermission() & IsAdminUser()
+    
+    admin_request = Mock(user=Mock(is_authenticated=True, is_staff=True))
+    assert await combined.has_permission_async(admin_request, None) is True
+    assert await combined.has_permission_async(authenticated_request, None) is False
+
+    assert combined.has_permission(admin_request, None) is True
+    assert combined.has_permission(authenticated_request, None) is False
+```
+
+For controller integration tests:
+
+```python
+@pytest.mark.asyncio
+async def test_controller_with_permissions():
+    @api_controller("/test")
+    class TestController(ControllerBase):
+        @http_get("/protected", permissions=[CustomAsyncPermission()])
+        async def protected_route(self):
+            return {"success": True}
+    
+    # Create async test client
+    client = TestAsyncClient(TestController)
+    
+    # Test with anonymous user
+    response = await client.get("/protected", user=AnonymousUser())
+    assert response.status_code == 403
+    
+    # Test with authenticated user
+    auth_user = Mock(is_authenticated=True)
+    response = await client.get("/protected", user=auth_user)
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+``` 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Index: api_controller/index.md
   - Controller Routes: api_controller/api_controller_route.md
   - Controller Permissions: api_controller/api_controller_permission.md
+  - Controller Async Permissions: api_controller/api_controller_async_permission.md
   - Model Controller:
     - Getting Started: api_controller/model_controller/01_getting_started.md
     - Model Configuration: api_controller/model_controller/02_model_configuration.md

--- a/ninja_extra/context.py
+++ b/ninja_extra/context.py
@@ -9,7 +9,7 @@ from ninja.types import DictStrAny
 
 from ninja_extra.interfaces.route_context import RouteContextBase
 from ninja_extra.lazy import settings_lazy
-from ninja_extra.types import PermissionType
+from ninja_extra.permissions import BasePermissionType
 
 if t.TYPE_CHECKING:
     from ninja_extra.details import ViewSignature
@@ -32,7 +32,7 @@ class RouteContext(RouteContextBase):
         "_has_computed_route_parameters",
     ]
 
-    permission_classes: PermissionType
+    permission_classes: t.List[BasePermissionType]
     request: t.Union[t.Any, HttpRequest, None]
     response: t.Union[t.Any, HttpResponse, None]
     args: t.List[t.Any]
@@ -42,7 +42,7 @@ class RouteContext(RouteContextBase):
         self,
         request: HttpRequest,
         args: t.Optional[t.List[t.Any]] = None,
-        permission_classes: t.Optional[PermissionType] = None,
+        permission_classes: t.Optional[t.List[BasePermissionType]] = None,
         kwargs: t.Optional[DictStrAny] = None,
         response: t.Optional[HttpResponse] = None,
         api: t.Optional["NinjaExtraAPI"] = None,
@@ -53,7 +53,7 @@ class RouteContext(RouteContextBase):
         self.args: t.List[t.Any] = args or []
         self.kwargs: DictStrAny = kwargs or {}
         self.kwargs.update({"view_func_kwargs": {}})
-        self.permission_classes: PermissionType = permission_classes or []
+        self.permission_classes: t.List[BasePermissionType] = permission_classes or []
         self._api = api
         self._view_signature = view_signature
         self._has_computed_route_parameters = False
@@ -115,7 +115,7 @@ class RouteContext(RouteContextBase):
 def get_route_execution_context(
     request: HttpRequest,
     temporal_response: t.Optional[HttpResponse] = None,
-    permission_classes: t.Optional[PermissionType] = None,
+    permission_classes: t.Optional[t.List[BasePermissionType]] = None,
     api: t.Optional["NinjaExtraAPI"] = None,
     view_signature: t.Optional["ViewSignature"] = None,
     *args: t.Any,

--- a/ninja_extra/permissions/__init__.py
+++ b/ninja_extra/permissions/__init__.py
@@ -1,11 +1,29 @@
-from .base import SAFE_METHODS, BasePermission
-from .common import AllowAny, IsAdminUser, IsAuthenticated, IsAuthenticatedOrReadOnly
+from .base import (
+    AND,
+    NOT,
+    OR,
+    SAFE_METHODS,
+    AsyncBasePermission,
+    BasePermission,
+    BasePermissionType,
+)
+from .common import (
+    AllowAny,
+    IsAdminUser,
+    IsAuthenticated,
+    IsAuthenticatedOrReadOnly,
+)
 
 __all__ = [
     "BasePermission",
+    "AsyncBasePermission",
     "SAFE_METHODS",
     "AllowAny",
     "IsAuthenticated",
     "IsAdminUser",
     "IsAuthenticatedOrReadOnly",
+    "AND",
+    "OR",
+    "NOT",
+    "BasePermissionType",
 ]

--- a/ninja_extra/permissions/base.py
+++ b/ninja_extra/permissions/base.py
@@ -3,60 +3,65 @@ Copied from DRF
 Provides a set of pluggable permission policies.
 """
 
+import typing as t
 from abc import ABC, ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Tuple, Type, TypeVar, Union
 
 from django.http import HttpRequest
-from ninja.types import DictStrAny
+from injector import is_decorated_with_inject
 
-if TYPE_CHECKING:  # pragma: no cover
+from ninja_extra.threading import execute_coroutine
+
+if t.TYPE_CHECKING:  # pragma: no cover
     from ninja_extra.controllers.base import ControllerBase  # pragma: no cover
 
 SAFE_METHODS = ("GET", "HEAD", "OPTIONS")
 
-T = TypeVar("T")
+T = t.TypeVar("T")
 
 
-class OperationHolderMixin:
+class _OperationHolderMixin:
     def __and__(  # type:ignore[misc]
-        self: Union[Type["BasePermission"], "BasePermission"],
-        other: Union[Type["BasePermission"], "BasePermission"],
-    ) -> "OperandHolder[AND]":
-        return OperandHolder(AND, self, other)
+        self: "BasePermissionType",
+        other: "BasePermissionType",
+    ) -> t.Union["BasePermission", "AsyncBasePermission"]:
+        return AND(self, other)
 
     def __or__(  # type:ignore[misc]
-        self: Union[Type["BasePermission"], "BasePermission"],
-        other: Union[Type["BasePermission"], "BasePermission"],
-    ) -> "OperandHolder[OR]":
-        return OperandHolder(OR, self, other)
+        self: "BasePermissionType",
+        other: "BasePermissionType",
+    ) -> t.Union["BasePermission", "AsyncBasePermission"]:
+        return OR(self, other)
 
     def __rand__(  # type:ignore[misc]
-        self: Union[Type["BasePermission"], "BasePermission"],
-        other: Union[Type["BasePermission"], "BasePermission"],
-    ) -> "OperandHolder[AND]":  # pragma: no cover
-        return OperandHolder(AND, other, self)
+        self: "BasePermissionType",
+        other: "BasePermissionType",
+    ) -> t.Union["BasePermission", "AsyncBasePermission"]:  # pragma: no cover
+        return AND(self, other)
 
     def __ror__(  # type:ignore[misc]
-        self: Union[Type["BasePermission"], "BasePermission"],
-        other: Union[Type["BasePermission"], "BasePermission"],
-    ) -> "OperandHolder[OR]":  # pragma: no cover
-        return OperandHolder(OR, other, self)
+        self: "BasePermissionType",
+        other: "BasePermissionType",
+    ) -> t.Union["BasePermission", "AsyncBasePermission"]:  # pragma: no cover
+        return OR(self, other)
 
     def __invert__(  # type:ignore[misc]
-        self: Union[Type["BasePermission"], "BasePermission"],
-    ) -> "SingleOperandHolder[NOT]":
-        return SingleOperandHolder(NOT, self)
+        self: "BasePermissionType",
+    ) -> t.Union["BasePermission", "AsyncBasePermission"]:
+        return NOT(self)
 
 
-class BasePermissionMetaclass(OperationHolderMixin, ABCMeta): ...
+class BasePermissionMetaclass(_OperationHolderMixin, ABCMeta):
+    pass
 
 
-class BasePermission(ABC, metaclass=BasePermissionMetaclass):  # pragma: no cover
+class BasePermission(
+    ABC, _OperationHolderMixin, metaclass=BasePermissionMetaclass
+):  # pragma: no cover
     """
     A base class from which all permission classes should inherit.
     """
 
-    message: Any = None
+    message: t.Any = None
 
     @abstractmethod
     def has_permission(
@@ -68,108 +73,329 @@ class BasePermission(ABC, metaclass=BasePermissionMetaclass):  # pragma: no cove
         return True
 
     def has_object_permission(
-        self, request: HttpRequest, controller: "ControllerBase", obj: Any
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
     ) -> bool:
         """
         Return `True` if permission is granted, `False` otherwise.
         """
         return True
 
+    @classmethod
+    def resolve(cls) -> t.Union["BasePermission", "AsyncBasePermission"]:
+        from ninja_extra import service_resolver
 
-class SingleOperandHolder(OperationHolderMixin, Generic[T]):
-    def __init__(
-        self,
-        operator_class: Type[BasePermission],
-        op1_class: Union[Type["BasePermission"], "BasePermission"],
-    ) -> None:
-        super().__init__()
-        self.operator_class = operator_class
-        self.op1_class = op1_class
-
-    def __call__(self, *args: Tuple[Any], **kwargs: DictStrAny) -> BasePermission:
-        op1 = self.op1_class
-        if isinstance(self.op1_class, (type, OperationHolderMixin)):
-            op1 = self.op1_class()
-        return self.operator_class(op1)  # type: ignore
+        if is_decorated_with_inject(getattr(cls, "__init__", cls)):
+            return service_resolver(  # type: ignore[return-value]
+                t.cast(t.Type[t.Union[BasePermission, AsyncBasePermission]], cls)
+            )
+        return cls()
 
 
-class OperandHolder(OperationHolderMixin, Generic[T]):
-    def __init__(
-        self,
-        operator_class: Type["BasePermission"],
-        op1_class: Union[Type["BasePermission"], "BasePermission"],
-        op2_class: Union[Type["BasePermission"], "BasePermission"],
-    ) -> None:
-        self.operator_class = operator_class
-        # Instance the Permission class before using it
-        self.op1 = op1_class
-        self.op2 = op2_class
-        self.message = op1_class.message
-        if isinstance(op1_class, (type, OperationHolderMixin)):
-            self.op1 = op1_class()
+class AsyncBasePermission(BasePermission, ABC):
+    """
+    A base class for asynchronous permission classes.
 
-        if isinstance(op2_class, (type, OperationHolderMixin)):
-            self.op2 = op2_class()
-
-    def __call__(self, *args: Tuple[Any], **kwargs: DictStrAny) -> BasePermission:
-        return self.operator_class(self.op1, self.op2)  # type: ignore
-
-
-class AND(BasePermission):
-    def __init__(self, op1: "BasePermission", op2: "BasePermission") -> None:
-        self.op1 = op1
-        self.op2 = op2
-        self.message = op1.message
+    This class extends the permission checking capabilities,
+    allowing for efficient permission checks with async Django models using asgiref.
+    """
 
     def has_permission(
         self, request: HttpRequest, controller: "ControllerBase"
     ) -> bool:
-        if self.op1.has_permission(request, controller):
-            self.message = self.op2.message
-            return self.op2.has_permission(request, controller)
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        res = execute_coroutine(self.has_permission_async(request, controller))
+        return t.cast(bool, res)
+
+    def has_object_permission(
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
+    ) -> bool:
+        """
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        res = execute_coroutine(
+            self.has_object_permission_async(request, controller, obj)
+        )
+        return t.cast(bool, res)
+
+    @abstractmethod
+    async def has_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase"
+    ) -> bool:
+        """
+        Asynchronous version of has_permission.
+        By default, it calls the synchronous has_permission method using sync_to_async.
+        Override this method to implement custom async permission logic.
+
+        Return `True` if permission is granted, `False` otherwise.
+        """
+
+    async def has_object_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
+    ) -> bool:
+        """
+        Asynchronous version of has_object_permission.
+        By default, it calls the synchronous has_object_permission method using sync_to_async.
+        Override this method to implement custom async object permission logic.
+
+        Return `True` if permission is granted, `False` otherwise.
+        """
+        return True
+
+
+BasePermissionType = t.Union[
+    BasePermission,
+    t.Type[BasePermission],
+    AsyncBasePermission,
+    t.Type[AsyncBasePermission],
+]
+
+
+class _OperandResolversMixin:
+    def resolve(self) -> t.Union["BasePermission", "AsyncBasePermission"]:
+        return t.cast(t.Union["BasePermission", "AsyncBasePermission"], self)
+
+    def _get_permission_object(
+        self, permission: BasePermissionType
+    ) -> t.Union[BasePermission, AsyncBasePermission]:
+        from ninja_extra import service_resolver
+
+        if isinstance(permission, type) and is_decorated_with_inject(
+            getattr(permission, "__init__", permission)
+        ):
+            return service_resolver(  # type: ignore[return-value]
+                permission
+            )
+        if isinstance(permission, type):
+            return permission()
+        return permission
+
+
+class AND(_OperandResolversMixin, AsyncBasePermission):
+    """
+    Logical AND operator for permissions.
+    Works with both sync and async permissions.
+    """
+
+    def __init__(
+        self,
+        op1: BasePermissionType,
+        op2: BasePermissionType,
+    ) -> None:
+        self.op1 = op1
+        self.op2 = op2
+        self.message = getattr(op1, "message", None)
+
+    def has_permission(
+        self, request: HttpRequest, controller: "ControllerBase"
+    ) -> bool:
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        if op1.has_permission(request, controller):
+            self.message = getattr(op2, "message", None)
+            return op2.has_permission(request, controller)
         return False
 
     def has_object_permission(
-        self, request: HttpRequest, controller: "ControllerBase", obj: Any
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
     ) -> bool:
-        return self.op1.has_object_permission(
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        return op1.has_object_permission(
             request, controller, obj
-        ) and self.op2.has_object_permission(request, controller, obj)
+        ) and op2.has_object_permission(request, controller, obj)
+
+    async def has_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase"
+    ) -> bool:
+        from asgiref.sync import sync_to_async
+
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        # Handle op1
+        if isinstance(op1, AsyncBasePermission):
+            if not await op1.has_permission_async(request, controller):
+                return False
+        else:
+            if not await sync_to_async(op1.has_permission)(request, controller):
+                return False
+
+        # Handle op2
+        self.message = getattr(op2, "message", None)
+        if isinstance(op2, AsyncBasePermission):
+            return await op2.has_permission_async(request, controller)
+        else:
+            return await sync_to_async(op2.has_permission)(request, controller)
+
+    async def has_object_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
+    ) -> bool:
+        from asgiref.sync import sync_to_async
+
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        # Handle op1
+        if isinstance(op1, AsyncBasePermission):
+            result1 = await op1.has_object_permission_async(request, controller, obj)
+        else:
+            result1 = await sync_to_async(op1.has_object_permission)(
+                request, controller, obj
+            )
+
+        # Short-circuit if first permission fails
+        if not result1:
+            return False
+
+        # Handle op2
+        if isinstance(op2, AsyncBasePermission):
+            result2 = await op2.has_object_permission_async(request, controller, obj)
+        else:
+            result2 = await sync_to_async(op2.has_object_permission)(
+                request, controller, obj
+            )
+
+        return result1 and result2
 
 
-class OR(BasePermission):
-    def __init__(self, op1: "BasePermission", op2: "BasePermission") -> None:
+class OR(_OperandResolversMixin, AsyncBasePermission):
+    """
+    Logical OR operator for permissions.
+    Works with both sync and async permissions.
+    """
+
+    def __init__(
+        self,
+        op1: BasePermissionType,
+        op2: BasePermissionType,
+    ) -> None:
         self.op1 = op1
         self.op2 = op2
-        self.message = op1.message
+        self.message = getattr(op1, "message", None)
 
     def has_permission(
         self, request: HttpRequest, controller: "ControllerBase"
     ) -> bool:
-        if not self.op1.has_permission(request, controller):
-            self.message = self.op2.message
-            return self.op2.has_permission(request, controller)
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        if not op1.has_permission(request, controller):
+            self.message = getattr(op2, "message", None)
+            return op2.has_permission(request, controller)
         return True
 
     def has_object_permission(
-        self, request: HttpRequest, controller: "ControllerBase", obj: Any
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
     ) -> bool:
-        return self.op1.has_object_permission(
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        return op1.has_object_permission(
             request, controller, obj
-        ) or self.op2.has_object_permission(request, controller, obj)
+        ) or op2.has_object_permission(request, controller, obj)
+
+    async def has_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase"
+    ) -> bool:
+        from asgiref.sync import sync_to_async
+
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        # Handle op1
+        if isinstance(op1, AsyncBasePermission):
+            if await op1.has_permission_async(request, controller):
+                return True
+        else:
+            if await sync_to_async(op1.has_permission)(request, controller):
+                return True
+
+        # Op1 failed, check op2
+        self.message = getattr(op2, "message", None)
+        if isinstance(op2, AsyncBasePermission):
+            return await op2.has_permission_async(request, controller)
+        else:
+            return await sync_to_async(op2.has_permission)(request, controller)
+
+    async def has_object_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
+    ) -> bool:
+        from asgiref.sync import sync_to_async
+
+        op1 = self._get_permission_object(self.op1)
+        op2 = self._get_permission_object(self.op2)
+
+        # Handle op1
+        if isinstance(op1, AsyncBasePermission):
+            result1 = await op1.has_object_permission_async(request, controller, obj)
+        else:
+            result1 = await sync_to_async(op1.has_object_permission)(
+                request, controller, obj
+            )
+
+        # Short-circuit if first permission succeeds
+        if result1:
+            return True
+
+        # Handle op2
+        if isinstance(op2, AsyncBasePermission):
+            return await op2.has_object_permission_async(request, controller, obj)
+        else:
+            return await sync_to_async(op2.has_object_permission)(
+                request, controller, obj
+            )
 
 
-class NOT(BasePermission):
-    def __init__(self, op1: "BasePermission") -> None:
+class NOT(_OperandResolversMixin, AsyncBasePermission):
+    """
+    Logical NOT operator for permissions.
+    Works with both sync and async permissions.
+    """
+
+    def __init__(self, op1: BasePermissionType) -> None:
         self.op1 = op1
-        self.message = op1.message
+        self.message = getattr(op1, "message", None)
 
     def has_permission(
         self, request: HttpRequest, controller: "ControllerBase"
     ) -> bool:
-        return not self.op1.has_permission(request, controller)
+        op1 = self._get_permission_object(self.op1)
+
+        return not op1.has_permission(request, controller)
 
     def has_object_permission(
-        self, request: HttpRequest, controller: "ControllerBase", obj: Any
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
     ) -> bool:
-        return not self.op1.has_object_permission(request, controller, obj)
+        op1 = self._get_permission_object(self.op1)
+
+        return not op1.has_object_permission(request, controller, obj)
+
+    async def has_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase"
+    ) -> bool:
+        from asgiref.sync import sync_to_async
+
+        op1 = self._get_permission_object(self.op1)
+
+        if isinstance(op1, AsyncBasePermission):
+            return not await op1.has_permission_async(request, controller)
+        else:
+            return not await sync_to_async(op1.has_permission)(request, controller)
+
+    async def has_object_permission_async(
+        self, request: HttpRequest, controller: "ControllerBase", obj: t.Any
+    ) -> bool:
+        from asgiref.sync import sync_to_async
+
+        op1 = self._get_permission_object(self.op1)
+
+        if isinstance(op1, AsyncBasePermission):
+            return not await op1.has_object_permission_async(request, controller, obj)
+        else:
+            return not await sync_to_async(op1.has_object_permission)(
+                request, controller, obj
+            )

--- a/ninja_extra/threading/__init__.py
+++ b/ninja_extra/threading/__init__.py
@@ -1,0 +1,3 @@
+from .sync_worker import execute_coroutine
+
+__all__ = ["execute_coroutine"]

--- a/ninja_extra/threading/sync_worker.py
+++ b/ninja_extra/threading/sync_worker.py
@@ -1,0 +1,130 @@
+"""
+Copied from BackendAI - http:github.com/lablup/backend.ai
+https://github.com/lablup/backend.ai/blob/4a19001f9d1ae12be7244e14b304d783da9ea4f9/src/ai/backend/client/session.py#L128
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import queue
+import threading
+import typing as t
+from contextvars import Context, copy_context
+
+_Item = t.TypeVar("_Item")
+
+logger = logging.getLogger("ellar")
+
+
+class _Sentinel(enum.Enum):
+    """
+    A special type to represent a special value to indicate closing/shutdown of queues.
+    """
+
+    TOKEN = 0
+
+    def __bool__(self) -> bool:  # pragma: no cover
+        # It should be evaluated as False when used as a boolean expr.
+        return False
+
+
+sentinel = _Sentinel.TOKEN
+
+
+class _SyncWorkerThread(threading.Thread):
+    work_queue: queue.Queue[
+        t.Union[
+            t.Tuple[
+                t.Union[t.AsyncIterator, t.Coroutine, t.AsyncContextManager], Context
+            ],
+            _Sentinel,
+        ]
+    ]
+    done_queue: queue.Queue[t.Union[t.Any, Exception]]
+    stream_queue: queue.Queue[t.Union[t.Any, Exception, _Sentinel]]
+    stream_block: threading.Event
+    agen_shutdown: bool
+
+    __slots__ = (
+        "work_queue",
+        "done_queue",
+        "stream_queue",
+        "stream_block",
+        "agen_shutdown",
+    )
+
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.work_queue = queue.Queue()
+        self.done_queue = queue.Queue()
+        self.stream_queue = queue.Queue()
+        self.stream_block = threading.Event()
+        self.agen_shutdown = False
+
+    def run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            while True:
+                item = self.work_queue.get()
+                if item is sentinel:
+                    break
+                coro, ctx = item
+                try:
+                    # FIXME: Once python/mypy#12756 is resolved, remove the type-ignore tag.
+                    result = ctx.run(loop.run_until_complete, coro)  # type: ignore[arg-type]
+                except Exception as e:
+                    self.done_queue.put_nowait(e)
+                    self.work_queue.task_done()
+                    raise e
+                else:
+                    self.done_queue.put_nowait(result)
+                    self.work_queue.task_done()
+
+        except (SystemExit, KeyboardInterrupt):  # pragma: no cover
+            pass
+        except Exception as ex:
+            logger.exception(ex)
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.stop()
+            loop.close()
+
+    def execute(self, coro: t.Coroutine) -> t.Any:
+        ctx = copy_context()  # preserve context for the worker thread
+        try:
+            self.work_queue.put((coro, ctx))
+            result = self.done_queue.get()
+            self.done_queue.task_done()
+            if isinstance(result, Exception):
+                raise result
+            return result
+        finally:
+            del ctx
+
+
+def execute_coroutine(coro: t.Coroutine) -> t.Any:
+    """
+    Run a coroutine function as synchronous function with SyncWorker
+
+    example:
+    ```python
+
+        async def coroutine_function():
+            return "Coroutine Function"
+
+        res = execute_coroutine(coroutine_function())
+        assert res == "Coroutine Function"
+    ```
+    """
+    _worker_thread = _SyncWorkerThread()
+    _worker_thread.start()
+
+    res = _worker_thread.execute(coro)
+
+    _worker_thread.work_queue.put(sentinel)
+    _worker_thread.join()
+
+    return res

--- a/ninja_extra/types.py
+++ b/ninja_extra/types.py
@@ -1,11 +1,13 @@
 from typing import Any, List, Type, Union
 
-from ninja_extra.permissions.base import (
-    BasePermission,
-    OperandHolder,
-    SingleOperandHolder,
-)
+from ninja_extra.permissions.base import AsyncBasePermission, BasePermission
 
 PermissionType = List[
-    Union[Type[BasePermission], OperandHolder, SingleOperandHolder, BasePermission, Any]
+    Union[
+        Type[BasePermission],
+        BasePermission,
+        Any,
+        Type[AsyncBasePermission],
+        AsyncBasePermission,
+    ]
 ]

--- a/tests/test_async_permissions.py
+++ b/tests/test_async_permissions.py
@@ -1,0 +1,519 @@
+from unittest.mock import Mock
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from injector import inject
+
+from ninja_extra import (
+    ControllerBase,
+    api_controller,
+    get_injector,
+    http_get,
+    http_post,
+    permissions,
+)
+from ninja_extra.permissions.base import AsyncBasePermission
+from ninja_extra.testing import TestAsyncClient
+
+
+# Create mock requests for testing
+@pytest.fixture
+def anonymous_request():
+    _request = Mock()
+    _request.user = AnonymousUser()
+    return _request
+
+
+@pytest.fixture
+def authenticated_request():
+    _request = Mock()
+    _request.user = Mock(is_authenticated=True, is_staff=False)
+    return _request
+
+
+@pytest.fixture
+def admin_request():
+    _request = Mock()
+    _request.user = Mock(is_authenticated=True, is_staff=True)
+    return _request
+
+
+# Custom async permissions for testing
+class TestAsyncPermission(AsyncBasePermission):
+    """Custom async permission that returns a specified result"""
+
+    def __init__(self, result=True):
+        self.result = result
+        self.message = "Test permission"
+
+    def has_permission(self, request, controller):
+        return self.result
+
+    async def has_permission_async(self, request, controller):
+        return self.result
+
+
+class PermissionCalledTracker(AsyncBasePermission):
+    """Permission that tracks when it's called"""
+
+    def __init__(self, result=True):
+        self.result = result
+        self.called_sync = False
+        self.called_async = False
+        self.message = "Tracker permission"
+
+    def has_permission(self, request, controller):
+        self.called_sync = True
+        return self.result
+
+    async def has_permission_async(self, request, controller):
+        self.called_async = True
+        return self.result
+
+
+class TestAsyncPermissionOperators:
+    """Tests for the AND, OR, NOT operators with async permissions"""
+
+    @pytest.mark.asyncio
+    async def test_and_operator_both_true(self):
+        """Test AND operator with both permissions returning True"""
+        perm1 = TestAsyncPermission(True)
+        perm2 = TestAsyncPermission(True)
+        combined = perm1 & perm2
+
+        assert await combined.has_permission_async(None, None) is True
+
+    @pytest.mark.asyncio
+    async def test_and_operator_first_false(self):
+        """Test AND operator with first permission returning False"""
+        perm1 = TestAsyncPermission(False)
+        perm2 = TestAsyncPermission(True)
+        combined = perm1 & perm2
+
+        tracker1 = PermissionCalledTracker(False)
+        tracker2 = PermissionCalledTracker(True)
+        combined_trackers = tracker1 & tracker2
+
+        assert await combined.has_permission_async(None, None) is False
+        assert await combined_trackers.has_permission_async(None, None) is False
+
+        # Second permission should not be called (short-circuit)
+        assert tracker1.called_async is True
+        assert tracker2.called_async is False
+
+    @pytest.mark.asyncio
+    async def test_and_operator_second_false(self):
+        """Test AND operator with second permission returning False"""
+        perm1 = TestAsyncPermission(True)
+        perm2 = TestAsyncPermission(False)
+        combined = perm1 & perm2
+
+        assert await combined.has_permission_async(None, None) is False
+
+    @pytest.mark.asyncio
+    async def test_or_operator_both_true(self):
+        """Test OR operator with both permissions returning True"""
+        perm1 = TestAsyncPermission(True)
+        perm2 = TestAsyncPermission(True)
+        combined = perm1 | perm2
+
+        tracker1 = PermissionCalledTracker(True)
+        tracker2 = PermissionCalledTracker(True)
+        combined_trackers = tracker1 | tracker2
+
+        assert await combined.has_permission_async(None, None) is True
+        assert await combined_trackers.has_permission_async(None, None) is True
+
+        # Second permission should not be called (short-circuit)
+        assert tracker1.called_async is True
+        assert tracker2.called_async is False
+
+    @pytest.mark.asyncio
+    async def test_or_operator_first_false(self):
+        """Test OR operator with first permission returning False"""
+        perm1 = TestAsyncPermission(False)
+        perm2 = TestAsyncPermission(True)
+        combined = perm1 | perm2
+
+        assert await combined.has_permission_async(None, None) is True
+
+    @pytest.mark.asyncio
+    async def test_or_operator_both_false(self):
+        """Test OR operator with both permissions returning False"""
+        perm1 = TestAsyncPermission(False)
+        perm2 = TestAsyncPermission(False)
+        combined = perm1 | perm2
+
+        assert await combined.has_permission_async(None, None) is False
+
+    @pytest.mark.asyncio
+    async def test_not_operator_true(self):
+        """Test NOT operator with permission returning True"""
+        perm = TestAsyncPermission(True)
+        negated = ~perm
+
+        assert await negated.has_permission_async(None, None) is False
+
+    @pytest.mark.asyncio
+    async def test_not_operator_false(self):
+        """Test NOT operator with permission returning False"""
+        perm = TestAsyncPermission(False)
+        negated = ~perm
+
+        assert await negated.has_permission_async(None, None) is True
+
+    @pytest.mark.asyncio
+    async def test_complex_expression(self):
+        """Test complex expression with multiple operators"""
+        perm1 = TestAsyncPermission(True)
+        perm2 = TestAsyncPermission(False)
+        perm3 = TestAsyncPermission(True)
+
+        # (True AND False) OR (NOT True) = False OR False = False
+        and_op = perm1 & perm2
+        not_op = ~perm3
+        expression = and_op | not_op
+        assert await expression.has_permission_async(None, None) is False
+
+        # (True OR False) AND (NOT False) = True AND True = True
+        or_op = perm1 | perm2
+        not_op = ~TestAsyncPermission(False)
+        expression = or_op & not_op
+        assert await expression.has_permission_async(None, None) is True
+
+
+class TestMixedSyncAsyncPermissions:
+    """Tests for mixing sync and async permissions"""
+
+    @pytest.mark.asyncio
+    async def test_sync_and_async_and(self, authenticated_request, admin_request):
+        """Test AND operator with sync and async permissions"""
+        sync_perm = permissions.IsAuthenticated()
+        async_perm = permissions.IsAdminUser()
+
+        # IsAuthenticated & IsAdminUser
+        combined = sync_perm & async_perm
+
+        # Anonymous user - should fail first check
+        anon_user = Mock(is_authenticated=False)
+        anon_request = Mock(user=anon_user)
+        assert await combined.has_permission_async(anon_request, None) is False
+
+        # Authenticated non-admin - should pass first check, fail second
+        assert await combined.has_permission_async(authenticated_request, None) is False
+
+        # Admin user - should pass both checks
+        assert await combined.has_permission_async(admin_request, None) is True
+
+    @pytest.mark.asyncio
+    async def test_sync_and_async_or(self, authenticated_request):
+        """Test OR operator with sync and async permissions"""
+        sync_perm = permissions.IsAuthenticated()
+        async_perm = permissions.AllowAny()
+
+        # IsAuthenticated | AllowAny
+        combined = sync_perm | async_perm
+
+        # Anonymous user - should fail first check, pass second
+        anon_user = Mock(is_authenticated=False)
+        anon_request = Mock(user=anon_user)
+        assert await combined.has_permission_async(anon_request, None) is True
+
+        # Authenticated user - should pass first check, short-circuit
+        tracker1 = PermissionCalledTracker(True)  # Sync perm
+        tracker2 = PermissionCalledTracker(True)  # Async perm
+        combined_trackers = tracker1 | tracker2
+
+        assert (
+            await combined_trackers.has_permission_async(authenticated_request, None)
+            is True
+        )
+        assert tracker1.called_async is True
+        assert tracker2.called_async is False
+
+    @pytest.mark.asyncio
+    async def test_inverted_mixed_permission(self, authenticated_request):
+        """Test inverting a mixed permission"""
+        # NOT IsAuthenticated
+        inverted = ~permissions.IsAuthenticated()
+
+        # Should be False for authenticated user
+        assert await inverted.has_permission_async(authenticated_request, None) is False
+
+        # Should be True for anonymous user
+        anon_user = Mock(is_authenticated=False)
+        anon_request = Mock(user=anon_user)
+        assert await inverted.has_permission_async(anon_request, None) is True
+
+
+@api_controller(
+    "permission/", permissions=[permissions.AllowAny, permissions.IsAdminUser()]
+)
+class AsyncController(ControllerBase):
+    @http_get("index/")
+    async def index(self):
+        return {"success": True}
+
+    @http_get(
+        "permission/",
+        permissions=[
+            permissions.IsAdminUser() & permissions.IsAuthenticatedOrReadOnly()
+        ],
+    )
+    async def permission_accept_type_and_instance(self):
+        return {"success": True}
+
+    @http_get(
+        "permission/async/",
+        permissions=[permissions.IsAdminUser() & permissions.IsAuthenticatedOrReadOnly],
+    )
+    async def permission_accept_type_and_instance_async(self):
+        return {"success": True}
+
+
+class TestAsyncController:
+    """Tests for the AsyncController class with async permissions"""
+
+    @pytest.mark.asyncio
+    async def test_controller_level_permissions(self):
+        """Test controller-level permissions (AllowAny & IsAdminUser)"""
+        # Create admin and normal users
+        admin_user = Mock(is_authenticated=True, is_staff=True)
+        normal_user = Mock(is_authenticated=True, is_staff=False)
+        anon_user = AnonymousUser()
+
+        # Use TestAsyncClient directly with the controller class
+        client = TestAsyncClient(AsyncController)
+
+        # Anonymous user should be rejected by IsAdminUser
+        response = await client.get("/index/", user=anon_user)
+        assert response.status_code == 403
+
+        # Normal authenticated user should be rejected by IsAdminUser
+        response = await client.get("/index/", user=normal_user)
+        assert response.status_code == 403
+
+        # Admin user should be allowed
+        response = await client.get("/index/", user=admin_user)
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+
+    @pytest.mark.asyncio
+    async def test_route_level_permissions(self):
+        """Test route-level permissions (IsAdminUser & IsAuthenticatedOrReadOnly)"""
+        # Create admin and normal users
+        admin_user = Mock(is_authenticated=True, is_staff=True)
+        normal_user = Mock(is_authenticated=True, is_staff=False)
+        anon_user = AnonymousUser()
+
+        # Use TestAsyncClient directly with the controller class
+        client = TestAsyncClient(AsyncController)
+
+        # Anonymous user making a GET request should be rejected because of combined permissions
+        response = await client.get("/permission/", user=anon_user)
+        assert response.status_code == 403
+
+        # Normal authenticated user should be rejected by IsAdminUser
+        response = await client.get("/permission/", user=normal_user)
+        assert response.status_code == 403
+
+        # Admin user should be allowed
+        response = await client.get("/permission/", user=admin_user)
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+
+    @pytest.mark.asyncio
+    async def test_route_level_permissions_with_class_reference(self):
+        """Test route-level permissions with class reference (IsAdminUser & IsAuthenticatedOrReadOnly)"""
+        # Create admin and normal users
+        admin_user = Mock(is_authenticated=True, is_staff=True)
+        normal_user = Mock(is_authenticated=True, is_staff=False)
+        anon_user = AnonymousUser()
+
+        # Use TestAsyncClient directly with the controller class
+        client = TestAsyncClient(AsyncController)
+
+        # Anonymous user making a GET request should be rejected because of combined permissions
+        response = await client.get("/permission/async/", user=anon_user)
+        assert response.status_code == 403
+
+        # Normal authenticated user should be rejected by IsAdminUser
+        response = await client.get("/permission/async/", user=normal_user)
+        assert response.status_code == 403
+
+        # Admin user should be allowed
+        response = await client.get("/permission/async/", user=admin_user)
+        assert response.status_code == 200
+        assert response.json() == {"success": True}
+
+    @pytest.mark.asyncio
+    async def test_permissions_with_different_http_methods(self):
+        """Test IsAuthenticatedOrReadOnly permission with different HTTP methods"""
+
+        # Create a new controller to test IsAuthenticatedOrReadOnly
+        @api_controller("read-only")
+        class ReadOnlyController(ControllerBase):
+            @http_get(
+                "resource/", permissions=[permissions.IsAuthenticatedOrReadOnly()]
+            )
+            async def get_resource(self):
+                return {"success": True}
+
+            @http_post(
+                "resource/", permissions=[permissions.IsAuthenticatedOrReadOnly()]
+            )
+            async def post_resource(self):
+                return {"success": True}
+
+        # Initialize the async test client with the controller class
+        client = TestAsyncClient(ReadOnlyController)
+
+        # Create authenticated and anonymous users
+        auth_user = Mock(is_authenticated=True)
+        anon_user = AnonymousUser()
+
+        # Anonymous user with GET (read) should be allowed
+        response = await client.get("/resource/", user=anon_user)
+        assert response.status_code == 200
+
+        # Anonymous user with POST (write) should be rejected
+        response = await client.post("/resource/", user=anon_user)
+        assert response.status_code == 403
+
+        # Authenticated user should be allowed for GET
+        response = await client.get("/resource/", user=auth_user)
+        assert response.status_code == 200
+
+        # Authenticated user should be allowed for POST
+        response = await client.post("/resource/", user=auth_user)
+        assert response.status_code == 200
+
+
+class TestInjectablePermissions:
+    """Tests for permission classes that use dependency injection with @inject"""
+
+    @pytest.mark.asyncio
+    async def test_injectable_permission_resolve(self):
+        """Test that permission classes with @inject are resolved correctly"""
+
+        # Create a service to be injected
+        class AuthService:
+            def is_admin(self, user):
+                return user.is_staff
+
+            def is_authenticated(self, user):
+                return user.is_authenticated
+
+        # Create a permission class that uses dependency injection
+        class InjectablePermission(AsyncBasePermission):
+            @inject
+            def __init__(self, auth_service: AuthService):
+                self.auth_service = auth_service
+                self.message = "Must be admin"
+
+            async def has_permission_async(self, request, controller):
+                return self.auth_service.is_admin(request.user)
+
+        # Register service with the injector
+        injector = get_injector()
+        injector.binder.bind(AuthService)
+        injector.binder.bind(InjectablePermission)
+
+        # Test resolving the permission directly
+        resolved_perm = InjectablePermission.resolve()
+
+        # Create request mocks for testing
+        admin_request = Mock(user=Mock(is_staff=True, is_authenticated=True))
+        normal_request = Mock(user=Mock(is_staff=False, is_authenticated=True))
+
+        # Test permission check works
+        assert resolved_perm.has_permission(admin_request, None) is True
+        assert resolved_perm.has_permission(normal_request, None) is False
+
+        # Test async permission check works
+        assert await resolved_perm.has_permission_async(admin_request, None) is True
+        assert await resolved_perm.has_permission_async(normal_request, None) is False
+
+    @pytest.mark.asyncio
+    async def test_injectable_permissions_with_operators(self):
+        """Test injected permissions with operators (AND, OR, NOT)"""
+
+        # Create services to be injected
+        class AuthService:
+            def is_admin(self, user):
+                return user.is_staff
+
+            def is_authenticated(self, user):
+                return user.is_authenticated
+
+        class PermissionService:
+            def is_special_user(self, user):
+                return getattr(user, "is_special", False)
+
+        # Create permission classes that use dependency injection
+
+        class AdminPermission(AsyncBasePermission):
+            @inject
+            def __init__(self, auth_service: AuthService):
+                self.auth_service = auth_service
+                self.message = "Must be admin"
+
+            async def has_permission_async(self, request, controller):
+                return self.auth_service.is_admin(request.user)
+
+        class SpecialUserPermission(AsyncBasePermission):
+            @inject
+            def __init__(self, permission_service: PermissionService):
+                self.permission_service = permission_service
+                self.message = "Must be special user"
+
+            async def has_permission_async(self, request, controller):
+                return self.permission_service.is_special_user(request.user)
+
+        # Register services with the injector
+        injector = get_injector()
+        injector.binder.bind(AuthService, to=AuthService)
+        injector.binder.bind(PermissionService, to=PermissionService)
+
+        # Create combined permissions using logical operators
+        and_perm = AdminPermission & SpecialUserPermission
+        or_perm = AdminPermission | SpecialUserPermission
+        not_perm = ~AdminPermission
+
+        # Create request mocks for testing
+        admin_special_request = Mock(
+            user=Mock(is_staff=True, is_authenticated=True, is_special=True)
+        )
+        admin_request = Mock(
+            user=Mock(is_staff=True, is_authenticated=True, is_special=False)
+        )
+        special_request = Mock(
+            user=Mock(is_staff=False, is_authenticated=True, is_special=True)
+        )
+        normal_request = Mock(
+            user=Mock(is_staff=False, is_authenticated=True, is_special=False)
+        )
+
+        # AND permission - requires both admin and special
+        and_result = await and_perm.has_permission_async(admin_special_request, None)
+        assert and_result is True
+        and_result = await and_perm.has_permission_async(admin_request, None)
+        assert and_result is False
+        and_result = await and_perm.has_permission_async(special_request, None)
+        assert and_result is False
+
+        # OR permission - requires either admin or special
+        or_result = await or_perm.has_permission_async(admin_special_request, None)
+        assert or_result is True
+        or_result = await or_perm.has_permission_async(admin_request, None)
+        assert or_result is True
+        or_result = await or_perm.has_permission_async(special_request, None)
+        assert or_result is True
+        or_result = await or_perm.has_permission_async(normal_request, None)
+        assert or_result is False
+
+        # NOT permission - requires NOT admin
+        not_result = await not_perm.has_permission_async(admin_request, None)
+        assert not_result is False
+        not_result = await not_perm.has_permission_async(normal_request, None)
+        assert not_result is True


### PR DESCRIPTION
## What's new 
- Added support for Async Permission #248 
- Permission Type can now inject services
- Ability to combine both `async` and `sync` permission types

```python
from ninja_extra import api_controller, http_get
from ninja_extra.permissions import IsAuthenticated, IsAdminUser, AsyncBasePermission

# Custom async permission
class HasPremiumSubscriptionAsync(AsyncBasePermission):
    async def has_permission_async(self, request, controller):
        # Async check
        user_profile = await request.user.profile.aget()
        return user_profile.has_premium_subscription

@api_controller("/content")
class ContentController:
    # User must be authenticated AND have premium subscription
    @http_get("/premium", permissions=[IsAuthenticated() & HasPremiumSubscriptionAsync()])
    async def premium_content(self, request):
        return {"content": "Premium content"}
    
    # User must be authenticated OR an admin
    @http_get("/special", permissions=[IsAuthenticated() | IsAdminUser()])
    async def special_content(self, request):
        return {"content": "Special content"}
    
    # User must be authenticated but NOT an admin
    @http_get("/regular", permissions=[IsAuthenticated() & ~IsAdminUser()])
    async def regular_content(self, request):
        return {"content": "Regular user content"}
```