### PR TITLE
Using apaginate_queryset when the paginator is AsyncPaginationBase

### DIFF
--- a/ninja_extra/pagination/operations.py
+++ b/ninja_extra/pagination/operations.py
@@ -17,6 +17,8 @@ from ninja_extra.shortcuts import add_ninja_contribute_args
 if TYPE_CHECKING:  # pragma: no cover
     from ninja_extra.controllers import ControllerBase
 
+import django
+
 
 class PaginatorOperation:
     def __init__(
@@ -110,10 +112,11 @@ class AsyncPaginatorOperation(PaginatorOperation):
                 request = request_or_controller
             params = dict(kw)
             params["request"] = request
-
+            is_supported_async_orm = django.VERSION >= (4, 2)
             paginate_queryset = (
                 self.paginator.apaginate_queryset
                 if isinstance(self.paginator, AsyncPaginationBase)
+                and is_supported_async_orm
                 else cast(Callable, sync_to_async(self.paginator.paginate_queryset))
             )
             return await paginate_queryset(items, **params)

--- a/ninja_extra/pagination/operations.py
+++ b/ninja_extra/pagination/operations.py
@@ -9,7 +9,7 @@ from typing import (
 
 from asgiref.sync import sync_to_async
 from django.http import HttpRequest
-from ninja.pagination import PaginationBase
+from ninja.pagination import AsyncPaginationBase, PaginationBase
 
 from ninja_extra.context import RouteContext
 from ninja_extra.shortcuts import add_ninja_contribute_args
@@ -22,7 +22,7 @@ class PaginatorOperation:
     def __init__(
         self,
         *,
-        paginator: PaginationBase,
+        paginator: Union[PaginationBase, AsyncPaginationBase],
         view_func: Callable,
         paginator_kwargs_name: str = "pagination",
     ) -> None:
@@ -110,8 +110,11 @@ class AsyncPaginatorOperation(PaginatorOperation):
                 request = request_or_controller
             params = dict(kw)
             params["request"] = request
-            paginate_queryset = cast(
-                Callable, sync_to_async(self.paginator.paginate_queryset)
+
+            paginate_queryset = (
+                self.paginator.apaginate_queryset
+                if isinstance(self.paginator, AsyncPaginationBase)
+                else cast(Callable, sync_to_async(self.paginator.paginate_queryset))
             )
             return await paginate_queryset(items, **params)
 


### PR DESCRIPTION
This diff introduces support for both synchronous and asynchronous pagination in the PaginatorOperation class in the ninja_extra/pagination/operations.py file. The key changes include:

1.  Import Updates:
    - Added AsyncPaginationBase to the imports from ninja.pagination, alongside the existing PaginationBase.

2.  Paginator Type Update:
    - The paginator parameter in the PaginatorOperation class's constructor is updated to accept either PaginationBase or AsyncPaginationBase using Union.

3.  Asynchronous Pagination Logic:
    - In the as_view method, the logic for handling pagination is updated to check the type of the paginator.
        - If the paginator is of type AsyncPaginationBase, its `apaginate_queryset` method is used.
        - Otherwise, the existing synchronous method (paginate_queryset) is wrapped with sync_to_async.

These changes enable the PaginatorOperation class to handle both synchronous and asynchronous pagination seamlessly, improving flexibility for developers using the library.