### PR TITLE
request_logger: use `django.request` instead of `django`

### DIFF
--- a/ninja_extra/logger.py
+++ b/ninja_extra/logger.py
@@ -1,3 +1,3 @@
 import logging
 
-request_logger = logging.getLogger("django")
+request_logger = logging.getLogger("django.request")


### PR DESCRIPTION
Django itself uses `django.request`. This allows one to easily silence request-level logs, without silencing all of Django.