### PR TITLE
change testing client to take a list of tuples in the query params

### DIFF
--- a/ninja_extra/testing/client.py
+++ b/ninja_extra/testing/client.py
@@ -33,7 +33,7 @@ class NinjaExtraClientBase(NinjaClientBase):
     ) -> "NinjaResponse":
         if json is not None:
             request_params["body"] = json_dumps(json, cls=NinjaJSONEncoder)
-        if "query" in request_params and isinstance(request_params["query"], dict):
+        if "query" in request_params and isinstance(request_params["query"], dict | list):
             query = request_params.pop("query")
             url_encode = urlencode(query)
             path = f"{path}?{url_encode}"


### PR DESCRIPTION
the function urlencode from urllib handles the case where in the input in query is a list of tuples, but it's not handled in django ninja extra

example:
client_test.get(f'/test', query=[('fields', 'field_name_1'), ('fields', 'field_name_2')]).json()

This will not work in the current version, but it would work if the isinstance(request_params["query"], dict) accepts a list as well

It's useful when passing a list of values for one query parameter.