### PR TITLE
fix response type for ModelController DELETE

### DIFF
--- a/ninja_extra/controllers/model/endpoints.py
+++ b/ninja_extra/controllers/model/endpoints.py
@@ -460,7 +460,7 @@ class ModelEndpointFactory:
             return route.delete(
                 working_path,
                 url_name=url_name,
-                response={status_code: str},
+                response={status_code: None},
                 description=description,
                 operation_id=operation_id,
                 summary=summary,


### PR DESCRIPTION
The DELETE endpoint for ModelControllers specifies a `str` response type, but it actually has an empty response body.

This causes tests to fail from e.g. Schemathesis, which check that the actual response matches the schema specified in openAPI.

This PR changes the respone type for `ModelEndpointFactory.delete()`