### PR TITLE
feat: Added Django Ninja FilterSchema support to Pagination Decorator And Model Controller

### DIFF
--- a/docs/tutorial/pagination.md
+++ b/docs/tutorial/pagination.md
@@ -4,9 +4,10 @@
 
 ## **Properties**
 
-`def paginate(func_or_pgn_class: Any = NOT_SET, **paginator_params: Any) -> Callable[..., Any]:`
+`def paginate(func_or_pgn_class: Any = NOT_SET, filter_schema: Optional[Type[FilterSchema]] = None, **paginator_params: Any) -> Callable[..., Any]:`
 
 - func_or_pgn_class: Defines a route function or a Pagination Class. default: `ninja_extra.pagination.LimitOffsetPagination`
+- filter_schema: Optional FilterSchema class from Django Ninja for filtering querysets before pagination
 - paginator_params: extra parameters for initialising Pagination Class
 
 ### **Using Ninja LimitOffsetPagination**
@@ -75,3 +76,127 @@ api.register_controllers(UserController)
 ```
 
 ![Preview](../images/pagination_example.gif)
+
+## **Pagination with Filtering**
+
+You can combine pagination with Django Ninja's `FilterSchema` to provide both filtering and pagination capabilities. Filters are applied to the queryset **before** pagination.
+
+!!! info "Learn More About FilterSchema"
+    For comprehensive information about FilterSchema features, custom expressions, combining filters, and advanced filtering techniques, see the official Django Ninja documentation: [https://django-ninja.dev/guides/input/filtering/](https://django-ninja.dev/guides/input/filtering/)
+
+### **Basic Filtering Example**
+
+```python
+from typing import Optional
+from ninja import FilterSchema
+from ninja_extra.pagination import paginate, PageNumberPaginationExtra, PaginatedResponseSchema
+from ninja_extra import api_controller, route, NinjaExtraAPI
+from ninja import ModelSchema
+from myapp.models import Book
+
+
+class BookSchema(ModelSchema):
+    class Config:
+        model = Book
+        model_fields = ['id', 'title', 'author', 'price', 'published_date']
+
+
+# Define a FilterSchema for your model
+class BookFilterSchema(FilterSchema):
+    title: Optional[str] = None
+    author: Optional[str] = None
+    min_price: Optional[float] = None
+
+
+@api_controller('/books')
+class BookController:
+    @route.get('', response=PaginatedResponseSchema[BookSchema])
+    @paginate(PageNumberPaginationExtra, filter_schema=BookFilterSchema, page_size=20)
+    def list_books(self):
+        return Book.objects.all()
+
+
+api = NinjaExtraAPI(title='Books API')
+api.register_controllers(BookController)
+```
+
+**Example API calls:**
+- `GET /api/books/?page=1&page_size=20` - Paginated results
+- `GET /api/books/?title=Python&page=1` - Filter by title and paginate
+- `GET /api/books/?author=John&min_price=10&page=2` - Multiple filters with pagination
+
+### **Advanced Filtering with Custom Lookups**
+
+Use Django Ninja's `FilterLookup` annotation for more complex filtering:
+
+```python
+from typing import Annotated, Optional
+from ninja import FilterSchema, FilterLookup
+
+
+class AdvancedBookFilterSchema(FilterSchema):
+    # Case-insensitive containment search
+    title: Annotated[Optional[str], FilterLookup("title__icontains")] = None
+    
+    # Exact match on author name
+    author: Annotated[Optional[str], FilterLookup("author__name__iexact")] = None
+    
+    # Greater than or equal to price
+    min_price: Annotated[Optional[float], FilterLookup("price__gte")] = None
+    
+    # Less than or equal to price
+    max_price: Annotated[Optional[float], FilterLookup("price__lte")] = None
+    
+    # Date range filtering
+    published_after: Annotated[Optional[str], FilterLookup("published_date__gte")] = None
+
+
+@api_controller('/books')
+class BookController:
+    @route.get('', response=PaginatedResponseSchema[BookSchema])
+    @paginate(PageNumberPaginationExtra, filter_schema=AdvancedBookFilterSchema, page_size=20)
+    def list_books(self):
+        return Book.objects.all()
+```
+
+### **Using FilterSchema with Model Controllers**
+
+FilterSchema can also be integrated with Model Controllers through the `ModelPagination` configuration:
+
+```python
+from ninja import FilterSchema
+from ninja_extra.controllers import ModelControllerBase
+from ninja_extra.controllers.model import ModelConfig, ModelPagination
+from ninja_extra.pagination import PageNumberPaginationExtra
+from myapp.models import Book
+
+
+class BookFilterSchema(FilterSchema):
+    title: Optional[str] = None
+    author__name: Optional[str] = None
+    price__gte: Optional[float] = None
+
+
+class BookModelController(ModelControllerBase):
+    model_config = ModelConfig(
+        model=Book,
+        pagination=ModelPagination(
+            klass=PageNumberPaginationExtra,
+            filter_schema=BookFilterSchema,
+            paginator_kwargs={"page_size": 25}
+        )
+    )
+```
+
+This configuration automatically applies the FilterSchema to the `list` endpoint of your Model Controller.
+
+### **How It Works**
+
+1. **Query Parameters**: When a request is made, both filter and pagination parameters are extracted from query parameters
+2. **Filtering**: The FilterSchema validates and applies filters to the queryset first
+3. **Pagination**: The filtered results are then paginated according to the pagination parameters
+4. **Response**: The paginated response includes filtered results with pagination metadata
+
+### **OpenAPI Schema**
+
+When using FilterSchema with pagination, the OpenAPI documentation automatically includes both filter parameters and pagination parameters, making your API self-documenting and easy to use.

--- a/ninja_extra/controllers/model/builder.py
+++ b/ninja_extra/controllers/model/builder.py
@@ -155,6 +155,9 @@ class ModelControllerBuilder:
             )
             if self._config.pagination.paginator_kwargs:  # pragma: no cover
                 paginate_kwargs.update(self._config.pagination.paginator_kwargs)
+            # Add filter_schema if provided
+            if self._config.pagination.filter_schema:
+                paginate_kwargs["filter_schema"] = self._config.pagination.filter_schema
 
         list_items = self._route_factory.list(
             path="/",

--- a/ninja_extra/controllers/model/endpoints.py
+++ b/ninja_extra/controllers/model/endpoints.py
@@ -3,6 +3,7 @@ import uuid
 
 from django.db.models import Model as DjangoModel
 from django.db.models import QuerySet
+from ninja import FilterSchema
 from ninja.constants import NOT_SET, NOT_SET_TYPE
 from ninja.pagination import PaginationBase
 from ninja.params import Body
@@ -392,6 +393,7 @@ class ModelEndpointFactory:
         pagination_class: t.Optional[
             t.Type[PaginationBase]
         ] = PageNumberPaginationExtra,
+        filter_schema: t.Optional[t.Type[FilterSchema]] = None,
         **paginate_kwargs: t.Any,
     ) -> ModelEndpointFunction:
         """
@@ -408,7 +410,9 @@ class ModelEndpointFactory:
             )
 
             if pagination_response_schema and pagination_class:
-                list_items = paginate(pagination_class, **paginate_kwargs)(list_items)
+                list_items = paginate(
+                    pagination_class, filter_schema=filter_schema, **paginate_kwargs
+                )(list_items)
                 return route.get(
                     working_path,
                     response=response


### PR DESCRIPTION
Add Django Ninja FilterSchema integration to the `paginate` decorator, enabling automatic filtering before pagination in both API controllers and Model Controllers.

Changes:
- Add filter_schema parameter to `paginate` decorator
- Integrate filter application in `PaginatorOperation` and `AsyncPaginatorOperation`
- Apply filters before pagination in both sync and async views
- Pass filter_schema from `ModelPagination` config to list endpoints for ModelController
- Add comprehensive tests for FilterSchema integration
- Update documentation with filtering examples and best practices

Features:
- Filters are automatically applied to querysets before pagination
- Works seamlessly with both synchronous and asynchronous views
- Compatible with Model Controllers through ModelPagination configuration
- Filter parameters registered as Query params in OpenAPI schema
- Supports all Django Ninja FilterSchema features (FilterLookup, custom expressions, etc.)