### PR TITLE
Fix for actually sub-classable controllers

### DIFF
--- a/ninja_extra/controllers/base.py
+++ b/ninja_extra/controllers/base.py
@@ -4,6 +4,7 @@ Base class for APIController.
 
 import inspect
 import re
+import types
 import uuid
 import warnings
 from abc import ABC
@@ -84,12 +85,110 @@ def get_route_functions(cls: Type) -> Iterable[RouteFunction]:
         Iterable[RouteFunction]: An iterable of route functions.
     """
 
-    bases = inspect.getmro(cls)
-    for base_cls in reversed(bases):
-        if base_cls not in [ControllerBase, ABC, object]:
-            for method in base_cls.__dict__.values():
-                if hasattr(method, ROUTE_FUNCTION):
-                    yield getattr(method, ROUTE_FUNCTION)
+    seen: set[str] = set()
+    for base_cls in inspect.getmro(cls):
+        if base_cls in [ControllerBase, ABC, object]:
+            continue
+        for attr_name, method in base_cls.__dict__.items():
+            if attr_name in seen:
+                continue
+            if hasattr(method, ROUTE_FUNCTION):
+                seen.add(attr_name)
+                yield getattr(method, ROUTE_FUNCTION)
+
+
+def _copy_route_enabled_function(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Create a deep copy of a function object to enable per-subclass route metadata.
+
+    When controllers inherit route-decorated methods, Python shares the same
+    function object across all subclasses. This causes route metadata (stored
+    as function attributes) to be overwritten by the last-registered controller.
+
+    This function creates a new function object with the same code, globals,
+    closure, and attributes, allowing each subclass to maintain independent
+    route metadata.
+
+    Args:
+        func: The route-decorated function to clone
+
+    Returns:
+        A new function object with copied attributes (excluding ROUTE_FUNCTION)
+
+    Note:
+        The ROUTE_FUNCTION attribute is intentionally excluded and will be
+        recreated by _attach_route_metadata() with subclass-specific metadata.
+    """
+    new_func = types.FunctionType(
+        func.__code__,
+        func.__globals__,
+        name=func.__name__,
+        argdefs=func.__defaults__,
+        closure=func.__closure__,
+    )
+    new_func.__kwdefaults__ = getattr(func, "__kwdefaults__", None)
+    new_func.__annotations__ = dict(getattr(func, "__annotations__", {}))
+    new_func.__doc__ = func.__doc__
+    new_func.__module__ = func.__module__
+    new_func.__qualname__ = func.__qualname__
+
+    # Copy over any custom attributes while skipping the route metadata – a fresh
+    # copy will be attached later for the subclass-specific function object.
+    if func.__dict__:
+        for key, value in func.__dict__.items():
+            if key == ROUTE_FUNCTION:
+                continue
+            new_func.__dict__[key] = value
+
+    return new_func
+
+
+def _attach_route_metadata(
+    target_func: Callable[..., Any], source_route: RouteFunction
+) -> None:
+    """
+    Recreate route metadata on a cloned function by reapplying the route decorator.
+
+    This function takes a freshly cloned function and reattaches route metadata
+    by invoking Route._create_route_function() with the original parameters.
+    This creates a new RouteFunction instance specific to the target function,
+    preventing metadata sharing between subclasses.
+
+    Args:
+        target_func: The cloned function that needs route metadata
+        source_route: The original RouteFunction containing metadata to copy
+
+    Note:
+        Uses a local import to avoid circular dependency issues between
+        controllers.base and controllers.route modules.
+    """
+    # Local import required to avoid circular dependency
+    from ninja_extra.controllers.route import Route
+
+    route = source_route.route
+    params = route.route_params
+
+    Route._create_route_function(
+        target_func,
+        path=params.path,
+        methods=list(params.methods),
+        auth=params.auth,
+        throttle=params.throttle,
+        response=params.response,
+        operation_id=params.operation_id,
+        summary=params.summary,
+        description=params.description,
+        tags=list(params.tags) if params.tags else None,
+        deprecated=params.deprecated,
+        by_alias=params.by_alias,
+        exclude_unset=params.exclude_unset,
+        exclude_defaults=params.exclude_defaults,
+        exclude_none=params.exclude_none,
+        url_name=params.url_name,
+        include_in_schema=params.include_in_schema,
+        permissions=route.permissions,
+        openapi_extra=params.openapi_extra,
+    )
 
 
 def get_all_controller_route_function(
@@ -480,6 +579,8 @@ class APIController:
         else:
             cls._api_controller = self
 
+        self._ensure_route_isolation(cls)
+
         assert isinstance(cls.throttling_classes, (list, tuple)), (
             f"Controller[{cls.__name__}].throttling_class must be a list or tuple"
         )
@@ -539,6 +640,45 @@ class APIController:
 
         ControllerRegistry().add_controller(cls)
         return cls
+
+    def _ensure_route_isolation(self, cls: Type["ControllerBase"]) -> None:
+        """
+        Ensure each controller subclass has its own copy of inherited route methods.
+
+        When a controller inherits route-decorated methods from a base class,
+        Python shares the same function object across all subclasses. This causes
+        route metadata mutations during registration to affect all subclasses,
+        resulting in URL resolution pointing to the wrong controller.
+
+        This method walks the MRO and creates per-subclass copies of inherited
+        route methods that haven't been explicitly overridden, ensuring each
+        controller maintains independent route metadata.
+
+        Example:
+            >>> class BaseController(ControllerBase):
+            ...     @http_get("/report")
+            ...     def report(self): ...
+            >>> 
+            >>> @api_controller("/alpha")
+            >>> class AlphaController(BaseController):
+            ...     pass  # gets its own copy of report()
+        """
+        for base_cls in cls.__mro__[1:]:
+            if base_cls in (ControllerBase, ABC, object):
+                continue
+
+            for attr_name, method in base_cls.__dict__.items():
+                # Skip if the subclass already overrides this method
+                if attr_name in cls.__dict__:
+                    continue
+
+                if hasattr(method, ROUTE_FUNCTION):
+                    cloned_func = _copy_route_enabled_function(method)
+                    cloned_func.__qualname__ = f"{cls.__qualname__}.{attr_name}"
+                    _attach_route_metadata(
+                        cloned_func, getattr(method, ROUTE_FUNCTION)
+                    )
+                    setattr(cls, attr_name, cloned_func)
 
     @property
     def path_operations(self) -> Dict[str, PathView]:

--- a/ninja_extra/controllers/model/builder.py
+++ b/ninja_extra/controllers/model/builder.py
@@ -51,7 +51,8 @@ class ModelControllerBuilder:
         )
 
     def _add_to_controller(self, func: t.Callable) -> None:
-        route_function = getattr(func, ROUTE_FUNCTION)
+        route_template = getattr(func, ROUTE_FUNCTION)
+        route_function = route_template.clone(func)
         route_function.api_controller = self._api_controller_instance
         self._api_controller_instance.add_controller_route_function(route_function)
 

--- a/ninja_extra/controllers/route/route_functions.py
+++ b/ninja_extra/controllers/route/route_functions.py
@@ -104,6 +104,26 @@ class RouteFunction(object):
         as_view.get_route_function = lambda: self  # type:ignore
         return as_view
 
+    def clone(self, view_func: Callable[..., Any]) -> "RouteFunction":
+        from ninja_extra.controllers.route import Route
+
+        route_params = self.route.route_params.dict()
+        permissions = self.route.permissions
+        if permissions is not None:
+            permissions = list(permissions)
+
+        if route_params["tags"] is not None:
+            route_params["tags"] = list(route_params["tags"])
+        route_params["methods"] = list(route_params["methods"])
+
+        cloned_route = Route(
+            view_func,
+            **route_params,
+            permissions=permissions,
+        )
+
+        return type(self)(route=cloned_route)
+
     def _process_view_function_result(self, result: Any) -> Any:
         """
         This process any a returned value from view_func

--- a/ninja_extra/controllers/route/route_functions.py
+++ b/ninja_extra/controllers/route/route_functions.py
@@ -2,7 +2,18 @@ import inspect
 import warnings
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from django.http import HttpRequest, HttpResponse
 
@@ -16,6 +27,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from ninja_extra.controllers.base import APIController, ControllerBase
     from ninja_extra.controllers.route import Route
     from ninja_extra.operation import Operation
+    from ninja_extra.permissions import BasePermission
+
+RoutePermissions = Optional[
+    List[Union[Type["BasePermission"], "BasePermission", Any]]
+]
 
 
 class RouteFunctionContext:
@@ -108,9 +124,11 @@ class RouteFunction(object):
         from ninja_extra.controllers.route import Route
 
         route_params = self.route.route_params.dict()
-        permissions = self.route.permissions
-        if permissions is not None:
-            permissions = list(permissions)
+        permissions: RoutePermissions
+        if self.route.permissions is None:
+            permissions = None
+        else:
+            permissions = cast(RoutePermissions, list(self.route.permissions))
 
         if route_params["tags"] is not None:
             route_params["tags"] = list(route_params["tags"])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -88,12 +88,12 @@ class ReportControllerBase(ControllerBase):
         return {"controller": type(self).__name__}
 
 
-@api_controller("/alpha")
+@api_controller("/alpha", urls_namespace="alpha")
 class AlphaReportController(ReportControllerBase):
     pass
 
 
-@api_controller("/beta")
+@api_controller("/beta", urls_namespace="beta")
 class BetaReportController(ReportControllerBase):
     pass
 


### PR DESCRIPTION
My motivation for #311 was to be able to define routes on a base Controller, then sub-class the controller and override parts of the implementation in the sub-classes.

Url-namespacing was necessary for that, but it revealed further problems when trying to actually use it.

Basically it seemed like when I fetched a route from ControllerA, method on ControllerB was getting called. Likely in some way because ControllerB was registered last.

I'm busy at day job, so I'll say up-front a disclaimer that the fix and description below have mostly been written by GPT-5-Codex. (We first prepared a failing test, then fixed it, then cleaned up the fix.)

I'll be happy to refine this by hand according to any review feedback.

## Summary

When a controller subclasses a base class that already defines Ninja Extra `@route`-decorated methods, the decorated function object is reused for every subclass. Registering multiple subclasses against the same `NinjaExtraAPI` causes the second registration to overwrite the route metadata created for the first. As a result, a URL that should resolve to controller A ends up bound to controller B (typically the most recently registered subclass).

## Reproduction

1. Define a base controller with a `@route`-decorated method (for example, `@route.generic("", methods=["GET"]) def report(self, request)`).
2. Create two concrete subclasses, each decorated with `@api_controller`, inheriting the base `report` implementation unchanged.
3. Register both subclasses against the same `NinjaExtraAPI` instance.
4. Resolve the URL for the first controller’s base route.

**Observed behaviour:** Django resolves the route to the second controller’s method; the first controller is never invoked when the shared route is hit.

## Root Cause

Python shares the exact same function object for the inherited `report` method (and any other inherited routed methods). `api_controller`/Ninja Extra mutates that function object during registration, attaching metadata such as `api_controller` and `operation`. The second registration overwrites those attributes, so every subclass now points to the most recently registered controller.

## Workaround

Override the route methods in each subclass and redecorate them locally:

```python
@route.generic("", methods=["GET", "POST"], response=None, url_name="html")
def report_html(self, request):
    return super().report_html(request)
```

By creating a distinct function object per subclass, each controller retains its own route metadata and URL resolution works again.

## Expected Behaviour

Registering multiple subclasses of a base controller (sharing a common routed method via inheritance) should keep their routes isolated. Each controller should own a separate `Operation`/metadata record without needing boilerplate overrides.

## Suggested Fix

During controller registration, Ninja Extra should copy or clone the route function per controller rather than mutating the inherited function object in place. That would mirror how Django CBVs create per-class bound views and prevent later registrations from hijacking earlier ones.
