### PR TITLE
Migrate from pydantic v1 config to pydantic v2 config

### DIFF
--- a/ninja_extra/conf/package_settings.py
+++ b/ninja_extra/conf/package_settings.py
@@ -4,7 +4,7 @@ from django.conf import settings as django_settings
 from django.core.signals import setting_changed
 from ninja.pagination import PaginationBase
 from ninja.throttling import BaseThrottle
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated
 
 from ninja_extra.conf.decorator import AllowTypeOfSource
@@ -61,9 +61,10 @@ USER_SETTINGS = UserDefinedSettingsMapper(
 
 
 class NinjaExtraSettings(BaseModel):
-    class Config:
-        from_attributes = True
-        validate_assignment = True
+    model_config = ConfigDict(
+        from_attributes=True,
+        validate_assignment=True,
+    )
 
     PAGINATION_CLASS: PaginationClassHandlerType = Field(  # type: ignore[assignment]
         "ninja.pagination.LimitOffsetPagination",


### PR DESCRIPTION
Using class Config raises a deprecation warning.
This commit migrates `NinjaExtraSettings` to the new ConfigDict version of the model config.

I saw that `class Config` also appeared in the files

```bash
./tests/test_model_controller/samples.py
./tests/test_model_controller/samples.py
./tests/controllers.py
```

but there the setting `orm_mode` is used, which isn't present in ConfigDict.

pydantic migration guide has [this](https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel) to say:

> The from_orm method has been deprecated; you can now just use model_validate (equivalent to parse_obj from Pydantic V1) to achieve something similar, as long as you've set from_attributes=True in the model config.


I don't feel competent to change these settings.
