### PR TITLE
feat(model-controller): Add `lookup_field` Configuration Option

### DIFF
--- a/ninja_extra/controllers/model/endpoints.py
+++ b/ninja_extra/controllers/model/endpoints.py
@@ -166,6 +166,7 @@ class ModelEndpointFactory:
         lookup_param: str,
         schema_in: t.Type[PydanticModel],
         schema_out: t.Type[PydanticModel],
+        lookup_field: str = "pk",
         status_code: int = status.HTTP_200_OK,
         auth: t.Any = NOT_SET,
         throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
@@ -202,6 +203,7 @@ class ModelEndpointFactory:
                     schema_in=schema_in,
                     object_getter=object_getter,
                     lookup_param=lookup_param,
+                    lookup_field=lookup_field,
                     custom_handler=custom_handler,
                 ),
                 prefix_route_params=api_controller.prefix_route_params,
@@ -237,6 +239,7 @@ class ModelEndpointFactory:
         lookup_param: str,
         schema_in: t.Type[PydanticModel],
         schema_out: t.Type[PydanticModel],
+        lookup_field: str = "pk",
         status_code: int = status.HTTP_200_OK,
         auth: t.Any = NOT_SET,
         throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
@@ -273,6 +276,7 @@ class ModelEndpointFactory:
                     object_getter=object_getter,
                     custom_handler=custom_handler,
                     lookup_param=lookup_param,
+                    lookup_field=lookup_field,
                     schema_in=schema_in,
                 ),
                 prefix_route_params=api_controller.prefix_route_params,
@@ -307,6 +311,7 @@ class ModelEndpointFactory:
         path: str,
         lookup_param: str,
         schema_out: t.Type[PydanticModel],
+        lookup_field: str = "pk",
         status_code: int = status.HTTP_200_OK,
         auth: t.Any = NOT_SET,
         throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
@@ -339,7 +344,9 @@ class ModelEndpointFactory:
             get_item = _path_resolver(
                 path,
                 cls._find_one_handler(
-                    object_getter=object_getter, lookup_param=lookup_param
+                    object_getter=object_getter,
+                    lookup_param=lookup_param,
+                    lookup_field=lookup_field,
                 ),
                 prefix_route_params=api_controller.prefix_route_params,
             )
@@ -472,6 +479,7 @@ class ModelEndpointFactory:
         cls,
         path: str,
         lookup_param: str,
+        lookup_field: str = "pk",
         status_code: int = status.HTTP_204_NO_CONTENT,
         auth: t.Any = NOT_SET,
         throttle: t.Union[BaseThrottle, t.List[BaseThrottle], NOT_SET_TYPE] = NOT_SET,
@@ -507,6 +515,7 @@ class ModelEndpointFactory:
                 cls._delete_handler(
                     object_getter=object_getter,
                     lookup_param=lookup_param,
+                    lookup_field=lookup_field,
                     custom_handler=custom_handler,
                     status_code=status_code,
                 ),
@@ -553,6 +562,7 @@ class ModelEndpointFactory:
         *,
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
         custom_handler: t.Optional[t.Callable[..., t.Any]],
         status_code: int,
     ) -> t.Callable:
@@ -561,7 +571,7 @@ class ModelEndpointFactory:
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one(pk=pk, **kwargs)
+                else self.service.get_one(pk=pk, lookup_field=lookup_field, **kwargs)
             )
             if not obj:  # pragma: no cover
                 raise NotFound()
@@ -580,13 +590,14 @@ class ModelEndpointFactory:
         *,
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
     ) -> t.Callable:
         def get_item(self: "ModelControllerBase", **kwargs: t.Any) -> t.Any:
             pk = kwargs.pop(lookup_param)
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one(pk=pk, **kwargs)
+                else self.service.get_one(pk=pk, lookup_field=lookup_field, **kwargs)
             )
             if not obj:  # pragma: no cover
                 raise NotFound()
@@ -603,6 +614,7 @@ class ModelEndpointFactory:
         schema_in: t.Type[PydanticModel],
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
         custom_handler: t.Optional[t.Callable[..., t.Any]],
     ) -> t.Callable:
         def patch_item(
@@ -614,7 +626,7 @@ class ModelEndpointFactory:
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one(pk=pk, **kwargs)
+                else self.service.get_one(pk=pk, lookup_field=lookup_field, **kwargs)
             )
             if not obj:  # pragma: no cover
                 raise NotFound()
@@ -637,6 +649,7 @@ class ModelEndpointFactory:
         schema_in: t.Type[PydanticModel],
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
         custom_handler: t.Optional[t.Callable[..., t.Any]],
     ) -> t.Callable:
         def update_item(
@@ -648,7 +661,7 @@ class ModelEndpointFactory:
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one(pk=pk, **kwargs)
+                else self.service.get_one(pk=pk, lookup_field=lookup_field, **kwargs)
             )
 
             if not obj:  # pragma: no cover
@@ -734,6 +747,7 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
         *,
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
         custom_handler: t.Optional[t.Callable[..., t.Any]],
         status_code: int,
     ) -> t.Callable:
@@ -742,7 +756,9 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one_async(pk=pk, **kwargs)
+                else self.service.get_one_async(
+                    pk=pk, lookup_field=lookup_field, **kwargs
+                )
             )
             obj = await _check_if_coroutine(obj)
             if not obj:  # pragma: no cover
@@ -767,13 +783,16 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
         *,
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
     ) -> t.Callable:
         async def get_item(self: "ModelControllerBase", **kwargs: t.Any) -> t.Any:
             pk = kwargs.pop(lookup_param)
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one_async(pk=pk, **kwargs)
+                else self.service.get_one_async(
+                    pk=pk, lookup_field=lookup_field, **kwargs
+                )
             )
             obj = await _check_if_coroutine(obj)
 
@@ -793,6 +812,7 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
         schema_in: t.Type[PydanticModel],
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
         custom_handler: t.Optional[t.Callable[..., t.Any]],
     ) -> t.Callable:
         async def patch_item(
@@ -804,7 +824,9 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one_async(pk=pk, **kwargs)
+                else self.service.get_one_async(
+                    pk=pk, lookup_field=lookup_field, **kwargs
+                )
             )
             obj = await _check_if_coroutine(obj)
 
@@ -834,6 +856,7 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
         schema_in: t.Type[PydanticModel],
         object_getter: t.Optional[t.Callable[..., DjangoModel]],
         lookup_param: str,
+        lookup_field: str = "pk",
         custom_handler: t.Optional[t.Callable[..., t.Any]],
     ) -> t.Callable:
         async def update_item(
@@ -845,7 +868,9 @@ class ModelAsyncEndpointFactory(ModelEndpointFactory):
             obj = (
                 object_getter(self, pk=pk, **kwargs)
                 if object_getter
-                else self.service.get_one_async(pk=pk, **kwargs)
+                else self.service.get_one_async(
+                    pk=pk, lookup_field=lookup_field, **kwargs
+                )
             )
             obj = await _check_if_coroutine(obj)
 

--- a/ninja_extra/controllers/model/schemas.py
+++ b/ninja_extra/controllers/model/schemas.py
@@ -90,6 +90,10 @@ class ModelConfig(PydanticModel):
         ]
     )
     async_routes: bool = False
+    lookup_field: str = Field(
+        default="pk",
+        description="The model field that should be used for performing object lookup of individual model instances. Defaults to 'pk'.",
+    )
     create_schema: t.Optional[t.Type[PydanticModel]] = None
     retrieve_schema: t.Optional[t.Type[PydanticModel]] = None
     update_schema: t.Optional[t.Type[PydanticModel]] = None

--- a/ninja_extra/controllers/model/service.py
+++ b/ninja_extra/controllers/model/service.py
@@ -22,8 +22,12 @@ class ModelService(ModelServiceBase, AsyncModelServiceBase):
         self.model = model
 
     def get_one(self, pk: t.Any, **kwargs: t.Any) -> t.Any:
+        lookup_field = kwargs.pop("lookup_field", "pk")
         obj = get_object_or_exception(
-            klass=self.model, error_message=None, exception=NotFound, pk=pk
+            klass=self.model,
+            error_message=None,
+            exception=NotFound,
+            **{lookup_field: pk},
         )
         return obj
 

--- a/tests/test_model_controller/samples.py
+++ b/tests/test_model_controller/samples.py
@@ -11,7 +11,7 @@ from ninja_extra import (
 )
 from ninja_extra.schemas import NinjaPaginationResponseSchema
 
-from ..models import Event
+from ..models import Client, Event
 
 
 class CreateEventSchema(ModelSchema):
@@ -128,4 +128,35 @@ class EventController(ModelControllerBase):
         lookup_param="event_id",
         object_getter=lambda self, pk, **kw: Event.objects.filter(id=pk).first(),
         custom_handler=lambda self, **kw: self.service.delete(**kw),
+    )
+
+
+# Schema for Client model
+class ClientSchema(ModelSchema):
+    class Config:
+        model = Client
+        include = ["id", "key"]
+
+
+class CreateClientSchema(ModelSchema):
+    class Config:
+        model = Client
+        include = ["key"]
+
+
+@api_controller("/client")
+class ClientModelControllerWithLookupField(ModelControllerBase):
+    """
+    Model Controller that uses 'key' as lookup_field instead of 'pk'.
+    This allows retrieving, updating, patching, and deleting clients by their key.
+    """
+
+    model_config = ModelConfig(
+        model=Client,
+        lookup_field="key",  # Use 'key' field for lookups instead of 'pk'
+        create_schema=CreateClientSchema,
+        retrieve_schema=ClientSchema,
+        update_schema=CreateClientSchema,
+        patch_schema=CreateClientSchema,
+        pagination=None,
     )

--- a/tests/test_model_controller/test_lookup_field.py
+++ b/tests/test_model_controller/test_lookup_field.py
@@ -1,0 +1,117 @@
+"""
+Tests for the lookup_field configuration in ModelController.
+
+The lookup_field option allows using a different field for object lookups
+instead of the default primary key ('pk'). This is similar to Django REST
+Framework's lookup_field option.
+"""
+
+import pytest
+
+from ninja_extra.testing import TestClient
+
+from ..models import Client
+from .samples import ClientModelControllerWithLookupField
+
+
+@pytest.mark.django_db
+def test_model_controller_with_lookup_field():
+    """
+    Test that ModelController correctly uses lookup_field='key' for all CRUD operations.
+
+    The Client model has a unique 'key' field, and this test verifies that:
+    - URLs use the key field (/{str:key}) instead of pk (/{int:id})
+    - GET, PUT, PATCH, DELETE operations lookup by key
+    """
+    client = TestClient(ClientModelControllerWithLookupField)
+
+    # CREATE - Create a new client with a unique key
+    test_key = "test-client-key-123"
+    res = client.post("/", json={"key": test_key})
+    assert res.status_code == 201
+    data = res.json()
+    assert data["key"] == test_key
+    client_id = data["id"]
+
+    # GET by key (not by id) - This is the key feature of lookup_field
+    res = client.get(f"/{test_key}")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["key"] == test_key
+    assert data["id"] == client_id
+
+    # LIST - should still work normally
+    res = client.get("/")
+    assert res.status_code == 200
+    data = res.json()
+    assert any(item["key"] == test_key for item in data)
+
+    # PUT by key - Update the client using key as lookup
+    new_key = "updated-key-456"
+    res = client.put(f"/{test_key}", json={"key": new_key})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["key"] == new_key
+    assert data["id"] == client_id  # Same id, different key
+
+    # PATCH by key - Patch the client using the new key
+    patched_key = "patched-key-789"
+    res = client.patch(f"/{new_key}", json={"key": patched_key})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["key"] == patched_key
+    assert data["id"] == client_id
+
+    # DELETE by key
+    res = client.delete(f"/{patched_key}")
+    assert res.status_code == 204
+
+    # Verify the client is deleted
+    assert not Client.objects.filter(key=patched_key).exists()
+
+
+@pytest.mark.django_db
+def test_model_controller_lookup_field_not_found():
+    """
+    Test that using a non-existent key returns 404.
+    """
+    client = TestClient(ClientModelControllerWithLookupField)
+
+    # GET with non-existent key should return 404
+    res = client.get("/non-existent-key")
+    assert res.status_code == 404
+
+    # PUT with non-existent key should return 404
+    res = client.put("/non-existent-key", json={"key": "new-key"})
+    assert res.status_code == 404
+
+    # PATCH with non-existent key should return 404
+    res = client.patch("/non-existent-key", json={"key": "new-key"})
+    assert res.status_code == 404
+
+    # DELETE with non-existent key should return 404
+    res = client.delete("/non-existent-key")
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_lookup_field_uses_correct_url_parameter_type():
+    """
+    Test that the URL parameter type matches the lookup field type.
+
+    For 'key' (CharField), the URL should use string type: /{str:key}
+    """
+    client = TestClient(ClientModelControllerWithLookupField)
+
+    # Create a client with a key containing special characters that are valid in URLs
+    special_key = "client-with-dashes"
+    res = client.post("/", json={"key": special_key})
+    assert res.status_code == 201
+
+    # Access using the string key
+    res = client.get(f"/{special_key}")
+    assert res.status_code == 200
+    assert res.json()["key"] == special_key
+
+    # Cleanup
+    Client.objects.filter(key=special_key).delete()


### PR DESCRIPTION
## Overview
Add support for custom lookup fields in ModelController, similar to
Django REST Framework's lookup_field option. This allows using any
unique field (e.g., slug, uuid, key) for object lookups instead of
the default primary key.

## Whats Changed:
- Add lookup_field option to ModelConfig (defaults to 'pk')
- Update ModelControllerBuilder to use lookup_field for URL parameters
- Update ModelService.get_one() to support custom lookup fields
- Update endpoint handlers to pass lookup_field to service layer
- Add tests for lookup_field functionality using Client model
- Add documentation with examples (slug, uuid, key fields)