### PR TITLE
Relax django-ninja dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 
 requires = [
     "Django >= 2.2",
-    "django-ninja == 1.5.1",
+    "django-ninja >= 1.5.1",
     "injector >= 0.19.0",
     "asgiref",
     "contextlib2"


### PR DESCRIPTION
Hey @eadwinCode,

the pinned version requirement of django-ninja currently blocks a couple of updates on my side, so I thought I'd change the pin to be greater equal instead of equal. Let me know what you think.