### PR TITLE
Replace deprecated get_api_controller() with api_controller property

### DIFF
--- a/ninja_extra/controllers/route/route_functions.py
+++ b/ninja_extra/controllers/route/route_functions.py
@@ -46,7 +46,7 @@ class RouteFunction(object):
         *args: Any,
         **kwargs: Any,
     ) -> Any:
-        _api_controller = self.get_api_controller()
+        _api_controller = self.api_controller
         context = get_route_execution_context(
             request,
             temporal_response,

--- a/ninja_extra/details.py
+++ b/ninja_extra/details.py
@@ -31,7 +31,7 @@ class ViewSignature(NinjaViewSignature):
                     route_function: "RouteFunction" = (
                         self.view_func.get_route_function()
                     )
-                    api_controller = route_function.get_api_controller()
+                    api_controller = route_function.api_controller
 
                     view_func = route_function.route.view_func
 

--- a/ninja_extra/operation.py
+++ b/ninja_extra/operation.py
@@ -114,7 +114,7 @@ class Operation(NinjaOperation):
             )
             route_function = self._get_route_function()
             if route_function:
-                api_controller = route_function.get_api_controller()
+                api_controller = route_function.api_controller
 
                 msg = (
                     f'"{request.method.upper() if request.method else "METHOD NOT FOUND"} - '
@@ -143,7 +143,7 @@ class Operation(NinjaOperation):
         if hasattr(self.view_func, "get_route_function"):
             route_function: "RouteFunction" = self.view_func.get_route_function()
 
-            _api_controller = route_function.get_api_controller()
+            _api_controller = route_function.api_controller
             permission_classes = (
                 route_function.route.permissions or _api_controller.permission_classes  # type: ignore[assignment]
             )


### PR DESCRIPTION
The `@deprecated` for the `get_api_controller()` method is causing tons of warnings to be fired off because ninja_extra is still using `get_api_controller()`.