### PR TITLE
Support queryset overrides in ModelService.get_one

### DIFF
--- a/ninja_extra/controllers/model/interfaces.py
+++ b/ninja_extra/controllers/model/interfaces.py
@@ -5,10 +5,19 @@ from django.db.models import Model as DjangoModel
 from django.db.models import QuerySet
 from pydantic import BaseModel as PydanticModel
 
+from ninja_extra.exceptions import APIException, NotFound
+
 
 class AsyncModelServiceBase(ABC):
     @abstractmethod
-    async def get_one_async(self, pk: t.Any, **kwargs: t.Any) -> t.Any:
+    async def get_one_async(
+        self,
+        pk: t.Any,
+        queryset: t.Optional[QuerySet] = None,
+        error_message: t.Optional[str] = None,
+        exception: t.Type[APIException] = NotFound,
+        **kwargs: t.Any,
+    ) -> t.Any:
         pass
 
     @abstractmethod
@@ -42,7 +51,14 @@ class ModelServiceBase(ABC):
     """
 
     @abstractmethod
-    def get_one(self, pk: t.Any, **kwargs: t.Any) -> t.Any:
+    def get_one(
+        self,
+        pk: t.Any,
+        queryset: t.Optional[QuerySet] = None,
+        error_message: t.Optional[str] = None,
+        exception: t.Type[APIException] = NotFound,
+        **kwargs: t.Any,
+    ) -> t.Any:
         pass
 
     @abstractmethod

--- a/ninja_extra/controllers/model/service.py
+++ b/ninja_extra/controllers/model/service.py
@@ -5,7 +5,7 @@ from asgiref.sync import sync_to_async
 from django.db.models import Model, QuerySet
 from pydantic import BaseModel as PydanticModel
 
-from ninja_extra.exceptions import NotFound
+from ninja_extra.exceptions import APIException, NotFound
 from ninja_extra.shortcuts import get_object_or_exception
 
 from .interfaces import AsyncModelServiceBase, ModelServiceBase
@@ -21,14 +21,37 @@ class ModelService(ModelServiceBase, AsyncModelServiceBase):
     def __init__(self, model: t.Type[Model]) -> None:
         self.model = model
 
-    def get_one(self, pk: t.Any, **kwargs: t.Any) -> t.Any:
+    def get_one(
+        self,
+        pk: t.Any,
+        queryset: t.Optional[QuerySet] = None,
+        error_message: t.Optional[str] = None,
+        exception: t.Type[APIException] = NotFound,
+        **kwargs: t.Any,
+    ) -> t.Any:
         obj = get_object_or_exception(
-            klass=self.model, error_message=None, exception=NotFound, pk=pk
+            klass=self.model if queryset is None else queryset,
+            error_message=error_message,
+            exception=exception,
+            pk=pk,
         )
         return obj
 
-    async def get_one_async(self, pk: t.Any, **kwargs: t.Any) -> t.Any:
-        return await sync_to_async(self.get_one, thread_sensitive=True)(pk, **kwargs)
+    async def get_one_async(
+        self,
+        pk: t.Any,
+        queryset: t.Optional[QuerySet] = None,
+        error_message: t.Optional[str] = None,
+        exception: t.Type[APIException] = NotFound,
+        **kwargs: t.Any,
+    ) -> t.Any:
+        return await sync_to_async(self.get_one, thread_sensitive=True)(
+            pk,
+            queryset=queryset,
+            error_message=error_message,
+            exception=exception,
+            **kwargs,
+        )
 
     def get_all(self, **kwargs: t.Any) -> t.Union[QuerySet, t.List[t.Any]]:
         return self.model.objects.all()

--- a/tests/test_model_controller/test_model_service_operation.py
+++ b/tests/test_model_controller/test_model_service_operation.py
@@ -1,8 +1,57 @@
-import pytest
+from datetime import date
+from typing import Any, Optional, Type
 
+import pytest
+from django.db.models import QuerySet
+
+from ninja_extra import ModelService, status
+from ninja_extra.exceptions import APIException, NotFound
 from ninja_extra.testing import TestClient
 
+from ..models import Category, Event
 from .model_service_with_sample import EventModelController
+
+
+class CustomBadRequest(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+
+
+class FilteredEventModelService(ModelService):
+    def get_one(
+        self,
+        pk: Any,
+        queryset: Optional[QuerySet] = None,
+        error_message: Optional[str] = None,
+        exception: Type[APIException] = NotFound,
+        **kwargs: Any,
+    ) -> Any:
+        queryset = self.model.objects.all() if queryset is None else queryset
+        return super().get_one(
+            pk=pk,
+            queryset=queryset.filter(category__isnull=False),
+            error_message=error_message,
+            exception=exception,
+            **kwargs,
+        )
+
+
+class DeepInheritedEventModelService(FilteredEventModelService):
+    def get_one(
+        self,
+        pk: Any,
+        queryset: Optional[QuerySet] = None,
+        error_message: Optional[str] = "Missing allowed event",
+        exception: Type[APIException] = CustomBadRequest,
+        **kwargs: Any,
+    ) -> Any:
+        queryset = self.model.objects.all() if queryset is None else queryset
+        return super().get_one(
+            pk=pk,
+            queryset=queryset.filter(title__startswith="Allowed"),
+            error_message=error_message,
+            exception=exception,
+            **kwargs,
+        )
 
 
 @pytest.mark.django_db
@@ -31,3 +80,61 @@ def test_model_service_injection():
         "category": None,
     }
     assert res.status_code == 200
+
+
+@pytest.mark.django_db
+def test_model_service_get_one_supports_queryset_error_message_and_exception():
+    category = Category.objects.create(title="Allowed category")
+    event = Event.objects.create(
+        title="Allowed event",
+        category=category,
+        start_date=date(2020, 1, 1),
+        end_date=date(2020, 1, 2),
+    )
+    service = ModelService(model=Event)
+
+    result = service.get_one(
+        pk=event.pk,
+        queryset=Event.objects.filter(title__startswith="Allowed"),
+    )
+
+    assert result == event
+
+    with pytest.raises(CustomBadRequest) as exception_info:
+        service.get_one(
+            pk=event.pk,
+            queryset=Event.objects.filter(title__startswith="Blocked"),
+            error_message="Blocked from lookup",
+            exception=CustomBadRequest,
+        )
+
+    assert exception_info.value.detail == "Blocked from lookup"
+    assert exception_info.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_model_service_get_one_supports_queryset_super_chaining():
+    allowed_category = Category.objects.create(title="Allowed category")
+    blocked_category = Category.objects.create(title="Blocked category")
+    allowed_event = Event.objects.create(
+        title="Allowed event",
+        category=allowed_category,
+        start_date=date(2020, 1, 1),
+        end_date=date(2020, 1, 2),
+    )
+    blocked_event = Event.objects.create(
+        title="Blocked event",
+        category=blocked_category,
+        start_date=date(2020, 1, 3),
+        end_date=date(2020, 1, 4),
+    )
+    service = DeepInheritedEventModelService(model=Event)
+
+    result = service.get_one(pk=allowed_event.pk)
+
+    assert result == allowed_event
+
+    with pytest.raises(CustomBadRequest) as exception_info:
+        service.get_one(pk=blocked_event.pk)
+
+    assert exception_info.value.detail == "Missing allowed event"


### PR DESCRIPTION
## Summary

  This PR updates ModelService.get_one() and get_one_async() to support explicit override parameters for:

  - queryset
  - error_message
  - exception

  This makes ModelService easier to extend through super() in deeper inheritance chains without reimplementing the base
  lookup logic.

## What changed

- Added explicit queryset, error_message, and exception parameters to:
    - ModelServiceBase.get_one
    - AsyncModelServiceBase.get_one_async
    - ModelService.get_one
    - ModelService.get_one_async
- Kept the default behavior unchanged when queryset is not provided:
    - lookup still uses self.model
- Added regression tests covering:
    - direct queryset override usage
    - custom error_message and exception
    - deep inherited super().get_one(...) chaining

## Why

Issue #309 describes a case where inherited services could not pass customized lookup behavior down to
ModelService.get_one() cleanly. With this change, service subclasses can do things like filter/annotate/prefetch on a
queryset and still rely on the base implementation for the final object retrieval and exception handling.

## Verification

Ran successfully:

- python -m pytest --cov=ninja_extra --cov-report=xml tests
- python -m ruff check ninja_extra tests
- python -m mypy ninja_extra

Closes #309