### PR TITLE
Update supported Python versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install Flit
         run: pip install flit "django>=6.0,<7"
       - name: Install Dependencies

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -11,20 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         django-version: ['<3.2', '<3.3', '<4.2', '<4.3', '<5.1', '<5.2', '<5.3', '<6.1']
         exclude:
-          - python-version: '3.8'
-            django-version: '<5.1'
-
-          - python-version: '3.9'
-            django-version: '<5.1'
-
           # Django 6.0+ requires Python 3.12+
-          - python-version: '3.8'
-            django-version: '<6.1'
-          - python-version: '3.9'
-            django-version: '<6.1'
           - python-version: '3.10'
             django-version: '<6.1'
           - python-version: '3.11'


### PR DESCRIPTION
## Summary

- Remove Python 3.8 and 3.9 from the full CI test matrix.
- Remove the corresponding obsolete matrix exclusions.
- Run the primary test and coverage workflow on Python 3.14 instead of 3.13.

## Why

Python 3.8 and 3.9 are end-of-life, while Python 3.14 is the newest stable version supported by the current Django compatibility range. Keeping the workflows aligned reduces obsolete CI jobs and ensures primary coverage exercises the newest supported runtime.

## Impact

This changes CI configuration only. It does not change the package's runtime metadata or application behavior.

## Validation

- Ran the repository pre-commit suite against both changed workflow files.
- Parsed both workflow files as YAML.
- Confirmed the commit contains only the two intended CI files.
