### PR TITLE
Release 0.31.6

### DIFF
--- a/ninja_extra/__init__.py
+++ b/ninja_extra/__init__.py
@@ -1,6 +1,6 @@
 """Django Ninja Extra - Class Based Utility and more for Django Ninja(Fast Django REST framework)"""
 
-__version__ = "0.31.5"
+__version__ = "0.31.6"
 
 import django
 


### PR DESCRIPTION
## Summary

- Bump `django-ninja-extra` from 0.31.5 to 0.31.6.
- Prepare the package metadata for the next PyPI release.

## Release validation

- `pytest`: 480 passed.
- Ruff formatting and linting: passed.
- Built the source distribution and wheel successfully.
- Confirmed both artifacts report version 0.31.6.

## Known validation note

The repository's mypy hook reports 10 existing errors in files outside this version-only change. The GitHub CI suite on the release base branch is green.
